### PR TITLE
0.8.0

### DIFF
--- a/components/md-editor.tsx
+++ b/components/md-editor.tsx
@@ -2,11 +2,12 @@ import React, {Dispatch, SetStateAction} from "react";
 import {simpleMDEToolbar} from "../utils/utils";
 import SimpleMDEEditor from "react-simplemde-editor";
 
-export default function MDEditor({body, setBody, imageUploadEndpoint, placeholder}: {
+export default function MDEditor({body, setBody, imageUploadEndpoint, placeholder, id}: {
     body: string,
     setBody: Dispatch<SetStateAction<string>>,
     imageUploadEndpoint: string,
     placeholder: string,
+    id: string,
 }) {
     return (
         <SimpleMDEEditor
@@ -19,6 +20,7 @@ export default function MDEditor({body, setBody, imageUploadEndpoint, placeholde
                 previewClass: "bg-white",
                 uploadImage: true,
                 imageUploadEndpoint: imageUploadEndpoint,
+                autosave: {enabled: true, uniqueId: id},
             }}
         />
     );

--- a/components/new-post-editor.tsx
+++ b/components/new-post-editor.tsx
@@ -101,6 +101,7 @@ export default function NewPostEditor(props: {
                     setBody={setBody}
                     imageUploadEndpoint={`/api/upload?projectId=${projectId}&attachedType=post&attachedUrlName=${props.tempId}`}
                     placeholder="Turn your snippets into a shareable post!"
+                    id={projectId}
                 />
             </div>
             <div className="flex mt-4">

--- a/components/new-post-editor.tsx
+++ b/components/new-post-editor.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import MDEditor from "./md-editor";
 import SpinnerButton from "./spinner-button";
 import {DatedObj, ProjectObj, UserObj} from "../utils/types";
@@ -36,6 +36,14 @@ export default function NewPostEditor(props: {
             value: "private",
         },
     ];
+
+    useEffect(() => {
+        window.onbeforeunload = !!body ? () => true : undefined;
+
+        return () => {
+            window.onbeforeunload = undefined;
+        };
+    }, [!!body]);
 
     return (
         <>

--- a/components/project-item.tsx
+++ b/components/project-item.tsx
@@ -15,7 +15,7 @@ export default function ProjectItem({project, owners, sessionUserId = null, isPr
 
     return (
         <div className="p-2 md:w-1/3">
-            <Link href={`/projects/${project._id}`}>
+            <Link href={isProjects ? `/projects/${project._id}` : `/@${owners.find(d => d._id === project.userId).username}/${project.urlName}`}>
                 <a className="block p-4 shadow-md rounded-md md:h-full relative pb-12 up-hover-parent">
                     <h3 className="up-ui-item-title leading-tight mb-2">{project.name}</h3>
                     {(project.userId !== sessionUserId) && (

--- a/components/public-post-item.tsx
+++ b/components/public-post-item.tsx
@@ -10,35 +10,48 @@ export default function PublicPostItem({post, author, project = null, urlPrefix}
     project?: DatedObj<ProjectObj>,
     urlPrefix: string,
 }) {
+    const imgUrl = post.body.match(/!\[.*?\]\((.*?)\)/) ? post.body.match(/!\[.*?\]\((.*?)\)/)[1] : null;
+
     return (
         <div className="opacity-75 hover:opacity-100 transition" key={post._id}>
-            <Link href={`/@${author.username}/p/${post.urlName}`}>
-                <a>
-                    <p className="up-ui-item-title mb-2">{post.title}</p>
-                    <p>
-                        <span>{format(new Date(post.createdAt), "MMMM d, yyyy")}</span>
-                        <span className="opacity-50"> | {readingTime(post.body).text}</span>
-                    </p>
-                </a>
-            </Link>
-            {project ? (
-                <Link href={`${urlPrefix}`}>
-                    <a className="block mt-4 opacity-50 hover:opacity-75 transition underline">
-                        {project.name}
-                    </a>
-                </Link>
-            ) : (
-                <Link href={`/@${author.username}`}>
-                    <a>
-                        <div className="mt-4 flex items-center opacity-50 hover:opacity-75 transition">
-                            <img src={author.image} alt={`Profile picture of ${author.name}`} className="w-8 h-8 rounded-full mr-4"/>
-                            <div>
-                                <p className="font-bold">{author.name}</p>
-                            </div>
-                        </div>
-                    </a>
-                </Link>
-            )}
+            <div className="flex">
+                <div>
+                    <Link href={`/@${author.username}/p/${post.urlName}`}>
+                        <a>
+                            <p className="up-ui-item-title mb-2">{post.title}</p>
+                            <p>
+                                <span>{format(new Date(post.createdAt), "MMMM d, yyyy")}</span>
+                                <span className="opacity-50"> | {readingTime(post.body).text}</span>
+                            </p>
+                        </a>
+                    </Link>
+                    {project ? (
+                        <Link href={`${urlPrefix}`}>
+                            <a className="block mt-4 opacity-50 hover:opacity-75 transition underline">
+                                {project.name}
+                            </a>
+                        </Link>
+                    ) : (
+                        <Link href={`/@${author.username}`}>
+                            <a>
+                                <div className="mt-4 flex items-center opacity-50 hover:opacity-75 transition">
+                                    <img src={author.image} alt={`Profile picture of ${author.name}`} className="w-8 h-8 rounded-full mr-4"/>
+                                    <div>
+                                        <p className="font-bold">{author.name}</p>
+                                    </div>
+                                </div>
+                            </a>
+                        </Link>
+                    )}
+                </div>
+                {imgUrl && (
+                    <Link href={`/@${author.username}/p/${post.urlName}`}>
+                        <a className="w-32 md:w-48 ml-auto pl-4 flex-shrink-0 block">
+                            <img className="w-full shadow-md" src={imgUrl} alt="Preview image for post"/>
+                        </a>
+                    </Link>
+                )}
+            </div>
             <hr className="my-10"/>
         </div>
     );

--- a/components/public-post-item.tsx
+++ b/components/public-post-item.tsx
@@ -19,12 +19,20 @@ export default function PublicPostItem({post, author, project = null, urlPrefix}
                     <Link href={`/@${author.username}/p/${post.urlName}`}>
                         <a>
                             <p className="up-ui-item-title mb-2">{post.title}</p>
-                            <p>
-                                <span>{format(new Date(post.createdAt), "MMMM d, yyyy")}</span>
-                                <span className="opacity-50"> | {readingTime(post.body).text}</span>
-                            </p>
                         </a>
                     </Link>
+                    <p>
+                        <span>{format(new Date(post.createdAt), "MMMM d, yyyy")}</span>
+                        <span className="opacity-50"> | {readingTime(post.body).text}</span>
+                        {!!post.tags.length && (
+                            <>
+                                <span className="opacity-50"> | </span>
+                                {post.tags.map(tag => (
+                                    <button className="opacity-50">#{tag} </button>
+                                ))}
+                            </>
+                        )}
+                    </p>
                     {project ? (
                         <Link href={`${urlPrefix}`}>
                             <a className="block mt-4 opacity-50 hover:opacity-75 transition underline">

--- a/components/snippet-editor.tsx
+++ b/components/snippet-editor.tsx
@@ -38,6 +38,7 @@ export default function SnippetEditor({isSnippet = false, snippet = null, projec
                     setBody={setBody}
                     imageUploadEndpoint={`/api/upload?projectId=${snippet ? snippet.projectId : projectId}&attachedType=snippet&attachedUrlName=${urlName}`}
                     placeholder={isSnippetState ? "Write down an interesting thought or development" : "Jot down some notes about this resource"}
+                    id={isSnippetState ? (projectId || snippet._id) + "snippet" : (projectId || snippet._id) + "resource"}
                 />
             </div>
             <hr className="my-6"/>

--- a/models/tag.ts
+++ b/models/tag.ts
@@ -1,0 +1,8 @@
+import mongoose, {Document, Model} from "mongoose";
+import {TagObj} from "../utils/types";
+
+const TagSchema = new mongoose.Schema({
+    key: { type: String, required: true },
+});
+
+export const TagModel: Model<Document<TagObj>> = mongoose.models.tag || mongoose.model("tag", TagSchema);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "updately-pro",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pages/[username]/[projectUrlName]/[postUrlName]/index.tsx
+++ b/pages/[username]/[projectUrlName]/[postUrlName]/index.tsx
@@ -84,6 +84,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         context.res.setHeader("location", `/@${thisAuthor._id}/p/${encodeURIComponent(postUrlName)}`);
         context.res.statusCode = 302;
         context.res.end();
+
+        return { props: {} };
     } catch (e) {
         console.log(e);
         return { notFound: true };

--- a/pages/[username]/index.tsx
+++ b/pages/[username]/index.tsx
@@ -21,6 +21,7 @@ export default function UserProfile({thisUser}: { thisUser: DatedObj<UserObj> })
     const [session, loading] = useSession();
     const {data: posts, error: postsError}: responseInterface<{ posts: DatedObj<PostObj>[], projects: DatedObj<ProjectObj>[], owners: DatedObj<UserObj>[] }, any> = useSWR(`/api/post?userId=${thisUser._id}`, fetcher);
     const {data: projects, error: projectsError}: responseInterface<{ projects: DatedObj<ProjectObjWithCounts>[], owners: DatedObj<UserObj>[] }, any> = useSWR(`/api/project?userId=${thisUser._id}`, fetcher);
+    const {data: tags, error: tagsError}: responseInterface<{ data: any }, any> = useSWR(`/api/tag?userId=${thisUser._id}`, fetcher);
 
     const postsReady = posts && posts.posts && posts.projects && posts.owners;
     const filteredPosts = postsReady ? posts.posts.filter(post => post.privacy === "public") : [];
@@ -50,6 +51,16 @@ export default function UserProfile({thisUser}: { thisUser: DatedObj<UserObj> })
                         <p className="mt-4 opacity-50"><Link href={`/@${thisUser.username}/edit`}><a className="underline">Edit your profile</a></Link> to add a bio.</p>
                     ))}
                     <p className="opacity-25 mt-2">Joined Postulate on {format(new Date(thisUser.createdAt), "MMMM d, yyyy")}</p>
+                    {tags && tags.data.length && (
+                        <>
+                            <hr className="my-8"/>
+                            <h3 className="up-ui-title mb-4">Tags</h3>
+                            {tags.data.map(tag => (
+                                <button className="opacity-50 hover:opacity-100 transition mr-3">#{tag._id} ({tag.count})</button>
+                            ))}
+                        </>
+                    )}
+
                 </div>
                 <div className="lg:w-2/3 lg:pl-12">
                     <hr className="my-10 lg:hidden"/>

--- a/pages/[username]/index.tsx
+++ b/pages/[username]/index.tsx
@@ -4,7 +4,7 @@ import {UserModel} from "../../models/user";
 import {cleanForJSON, fetcher} from "../../utils/utils";
 import {DatedObj, PostObj, ProjectObj, ProjectObjWithCounts, UserObj} from "../../utils/types";
 import UpSEO from "../../components/up-seo";
-import React from "react";
+import React, {useState} from "react";
 import {format} from "date-fns";
 import useSWR, {responseInterface} from "swr";
 import PublicPostItem from "../../components/public-post-item";
@@ -16,10 +16,12 @@ import MoreMenuItem from "../../components/more-menu-item";
 import {FiEdit2} from "react-icons/fi";
 import Link from "next/link";
 import Linkify from "react-linkify";
+import UpBanner from "../../components/UpBanner";
 
 export default function UserProfile({thisUser}: { thisUser: DatedObj<UserObj> }) {
     const [session, loading] = useSession();
-    const {data: posts, error: postsError}: responseInterface<{ posts: DatedObj<PostObj>[], projects: DatedObj<ProjectObj>[], owners: DatedObj<UserObj>[] }, any> = useSWR(`/api/post?userId=${thisUser._id}`, fetcher);
+    const [tag, setTag] = useState<string>("");
+    const {data: posts, error: postsError}: responseInterface<{ posts: DatedObj<PostObj>[], projects: DatedObj<ProjectObj>[], owners: DatedObj<UserObj>[] }, any> = useSWR(`/api/post?userId=${thisUser._id}&tag=${tag}`, fetcher);
     const {data: projects, error: projectsError}: responseInterface<{ projects: DatedObj<ProjectObjWithCounts>[], owners: DatedObj<UserObj>[] }, any> = useSWR(`/api/project?userId=${thisUser._id}`, fetcher);
     const {data: tags, error: tagsError}: responseInterface<{ data: any }, any> = useSWR(`/api/tag?userId=${thisUser._id}`, fetcher);
 
@@ -56,7 +58,7 @@ export default function UserProfile({thisUser}: { thisUser: DatedObj<UserObj> })
                             <hr className="my-8"/>
                             <h3 className="up-ui-title mb-4">Tags</h3>
                             {tags.data.map(tag => (
-                                <button className="opacity-50 hover:opacity-100 transition mr-3">#{tag._id} ({tag.count})</button>
+                                <button className="opacity-50 hover:opacity-100 transition mr-3" onClick={() => setTag(tag._id)}>#{tag._id} ({tag.count})</button>
                             ))}
                         </>
                     )}
@@ -77,6 +79,14 @@ export default function UserProfile({thisUser}: { thisUser: DatedObj<UserObj> })
                         <Skeleton count={10}/>
                     )}
                     <hr className="my-10"/>
+                    {tag && (
+                        <UpBanner className="mb-8">
+                            <div className="md:flex items-center w-full">
+                                <p>Showing posts with the tag <b>#{tag}</b></p>
+                                <button className="up-button text ml-auto" onClick={() => setTag("")}>Clear</button>
+                            </div>
+                        </UpBanner>
+                    )}
                     <h3 className="up-ui-title mb-8">Public posts ({postsReady ? filteredPosts.length : "Loading..."})</h3>
                     {postsReady ? filteredPosts.length > 0 ? filteredPosts.map(post => (
                         <PublicPostItem

--- a/pages/[username]/p/[postUrlName].tsx
+++ b/pages/[username]/p/[postUrlName].tsx
@@ -130,6 +130,16 @@ export default function PublicPost(props: {
                     </p>
                 </div>
             </div>
+            {!!props.postData.tags.length && (
+                <div className="my-8 opacity-50">
+                    <span>Tags: </span>
+                    {props.postData.tags.map(tag => (
+                        <Link href="">
+                            <a className="font-bold">#{tag}</a>
+                        </Link>
+                    ))}
+                </div>
+            )}
             <hr className="my-8"/>
             <div className="content prose">
                 {Parser(markdownConverter.makeHtml(body))}

--- a/pages/api/post.ts
+++ b/pages/api/post.ts
@@ -173,6 +173,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 await dbConnect();
 
                 let conditions: any = req.query.projectId ? { projectId: req.query.projectId } : { userId: req.query.userId };
+                conditions["privacy"] = "public";
                 if (req.query.search) conditions["$text"] = {"$search": req.query.search};
                 if (req.query.tag) conditions["tags"] = req.query.tag;
 

--- a/pages/api/tag.ts
+++ b/pages/api/tag.ts
@@ -1,6 +1,9 @@
 import {NextApiRequest, NextApiResponse} from "next";
 import dbConnect from "../../utils/dbConnect";
 import {TagModel} from "../../models/tag";
+import {UserModel} from "../../models/user";
+import {PostModel} from "../../models/post";
+import * as mongoose from "mongoose";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method !== "GET") return res.status(405);
@@ -8,11 +11,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     try {
         await dbConnect();
 
-        const conditions: any = req.query.query ? { $text: { $search: req.query.query }} : {};
+        // if for user profile, else in general
+        if (req.query.userId && !Array.isArray(req.query.userId)) {
+            const graphObj = await PostModel.aggregate([
+                {"$match": {"userId": mongoose.Types.ObjectId(req.query.userId)}},
+                {"$project": {"tags": 1}},
+                {"$unwind": "$tags"},
+                {"$group": {"_id": "$tags", "count": { "$sum": 1}}},
+                {"$sort": {"count": -1}},
+            ]);
 
-        const tags = await TagModel.find(conditions).limit(10);
+            return res.status(200).json({data: graphObj});
+        } else {
+            const conditions: any = req.query.query ? { $text: { $search: req.query.query }} : {};
 
-        return res.status(200).json({tags: tags});
+            const tags = await TagModel.find(conditions).limit(10);
+
+            return res.status(200).json({tags: tags});
+        }
     } catch (e) {
         return res.status(500).json({message: e});
     }

--- a/pages/api/tag.ts
+++ b/pages/api/tag.ts
@@ -1,0 +1,19 @@
+import {NextApiRequest, NextApiResponse} from "next";
+import dbConnect from "../../utils/dbConnect";
+import {TagModel} from "../../models/tag";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== "GET") return res.status(405);
+
+    try {
+        await dbConnect();
+
+        const conditions: any = req.query.query ? { $text: { $search: req.query.query }} : {};
+
+        const tags = await TagModel.find(conditions).limit(10);
+
+        return res.status(200).json({tags: tags});
+    } catch (e) {
+        return res.status(500).json({message: e});
+    }
+}

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -75,6 +75,10 @@ export interface ImageObj {
     size: number, // size of image in bytes
 }
 
+export interface TagObj {
+    key: string,
+}
+
 // generic / type alias from https://stackoverflow.com/questions/26652179/extending-interface-with-generic-in-typescript
 export type DatedObj<T extends {}> = T & {
     _id: string,


### PR DESCRIPTION
- Autosave posts (and snippets!) (PS-6)
- Image preview for public posts in item view (PS-63)
- Tags for posts (PS-64)
- Public profiles have private project links (bug, PS-66)
- Post pagination within user page (PS-67)
- Old links don't redirect, giving 500 error for not returning props object (bug, PS-68)
- Alert to confirm closing window with work in it (PS-70)

Removed from scope:
- Search for posts within user page (PS-55)
- Post editor is laggy to write in (bug, PS-62)
- Opening "select snippets" modal crashes app (bug, PS-69, unable to reproduce)