### PR TITLE
0.21.0

### DIFF
--- a/components/PostFeedItem.tsx
+++ b/components/PostFeedItem.tsx
@@ -6,7 +6,7 @@ import {findImages} from "../utils/utils";
 import {format} from "date-fns";
 import readingTime from "reading-time";
 
-export default function PostFeedItem({post, className, i}: { post: DatedObj<PostObjGraph>, className?: string, i?: number }) {
+export default function PostFeedItem({post, className, i, notFeed}: { post: DatedObj<PostObjGraph>, className?: string, i?: number, notFeed?: boolean, }) {
     const images = findImages(post.slateBody);
     const author = post.authorArr[0];
     const project = post.projectArr[0];
@@ -21,11 +21,11 @@ export default function PostFeedItem({post, className, i}: { post: DatedObj<Post
     )
 
     return (
-        <div className={"md:w-1/2 md:px-8 inline-block mb-12 " + (className || "")}>
-            {i === 1 && (
+        <div className={notFeed ? "mb-12" : "md:w-1/2 md:px-8 inline-block mb-12 " + (className || "")}>
+            {i === 1 && !notFeed && (
                 <hr className="up-border-gray-400 mb-12 md:hidden"/>
             )}
-            {!(i === 0 || i === 1) && (
+            {!(i === 0 || (i === 1 && !notFeed)) && (
                 <hr className="up-border-gray-400 mb-12"/>
             )}
             <LinkWrapper>

--- a/components/PostFeedItem.tsx
+++ b/components/PostFeedItem.tsx
@@ -1,4 +1,4 @@
-import {DatedObj, PostObjGraph} from "../utils/types";
+import {DatedObj, PostObj, PostObjGraph, PostObjWithAuthor} from "../utils/types";
 import Link from "next/link";
 import H3 from "./style/H3";
 import React, {ReactNode} from "react";
@@ -6,11 +6,9 @@ import {findImages} from "../utils/utils";
 import {format} from "date-fns";
 import readingTime from "reading-time";
 
-export default function PostFeedItem({post, className, i, notFeed}: { post: DatedObj<PostObjGraph>, className?: string, i?: number, notFeed?: boolean, }) {
+export default function PostFeedItem({post, className, i, notFeed}: { post: DatedObj<PostObjWithAuthor>, className?: string, i?: number, notFeed?: boolean, }) {
     const images = findImages(post.slateBody);
     const author = post.authorArr[0];
-    const project = post.projectArr[0];
-    const owner = project.ownerArr[0];
 
     const LinkWrapper = ({children, className}: {children: ReactNode, className?: string}) => (
         <Link href={`/@${author.username}/p/${post.urlName}`}>

--- a/components/PostFeedItem.tsx
+++ b/components/PostFeedItem.tsx
@@ -1,6 +1,5 @@
-import {DatedObj, PostObj, PostObjGraph, PostObjWithAuthor} from "../utils/types";
+import {DatedObj, PostObjWithAuthor} from "../utils/types";
 import Link from "next/link";
-import H3 from "./style/H3";
 import React, {ReactNode} from "react";
 import {findImages} from "../utils/utils";
 import {format} from "date-fns";

--- a/components/ProfileShell.tsx
+++ b/components/ProfileShell.tsx
@@ -7,12 +7,13 @@ import ProfileSidebarProjectItem from "./ProfileSidebarProjectItem";
 import {FiMenu, FiX} from "react-icons/fi";
 import UpInlineButton from "./style/UpInlineButton";
 
-export default function ProfileShell({thisUser, children, featured, selectedProjectId, isSnippet}: {
+export default function ProfileShell({thisUser, children, featured, selectedProjectId, isSnippet, isAllProjects}: {
     thisUser: DatedObj<UserObjWithProjects>,
     children: ReactNode,
     featured?: boolean,
     selectedProjectId?: string,
     isSnippet?: boolean,
+    isAllProjects?: boolean,
 }) {
     const featuredProjects = thisUser.projectsArr.filter(d => thisUser.featuredProjects.includes(d._id));
     const thisProject = selectedProjectId && thisUser.projectsArr.find(d => d._id === selectedProjectId);
@@ -31,7 +32,7 @@ export default function ProfileShell({thisUser, children, featured, selectedProj
             </Link>
             <p className="up-gray-400 mb-12 underline-links"><Linkify>{thisUser.bio}</Linkify></p>
             <ProfileSidebarProjectItem name="Home" href={`/@${thisUser.username}`} selected={featured} mobile={!!props.mobile}/>
-            {!featured && !featuredProjects.some(d => d._id === selectedProjectId) && ((() => {
+            {!(featured || isAllProjects) && !featuredProjects.some(d => d._id === selectedProjectId) && ((() => {
                 const thisProject = thisUser.projectsArr.find(d => d._id === selectedProjectId);
                 return (
                     <ProfileSidebarProjectItem
@@ -50,6 +51,7 @@ export default function ProfileShell({thisUser, children, featured, selectedProj
                     selected={project._id === selectedProjectId}
                 />
             ))}
+            <ProfileSidebarProjectItem name="All projects" href={`/@${thisUser.username}/projects`} selected={isAllProjects} mobile={!!props.mobile}/>
             <hr className="my-4 invisible"/>
         </div>
     )
@@ -69,7 +71,7 @@ export default function ProfileShell({thisUser, children, featured, selectedProj
                             <img src={thisUser.image} alt={`Profile picture of ${thisUser.name}`} className="w-6 h-6 rounded-full"/>
                             <p className="ml-2">{thisUser.name}</p>
                         </UpInlineButton>
-                        {!featured && selectedProjectId && (
+                        {!(featured || isAllProjects) && selectedProjectId && (
                             <>
                                 <span className="mx-2 up-gray-300">/</span>
                                 <UpInlineButton href={`/@${thisUser.username}/${thisProject.urlName}`} light={true}>

--- a/components/ProfileShell.tsx
+++ b/components/ProfileShell.tsx
@@ -7,7 +7,13 @@ import ProfileSidebarProjectItem from "./ProfileSidebarProjectItem";
 import {FiMenu, FiX} from "react-icons/fi";
 import UpInlineButton from "./style/UpInlineButton";
 
-export default function ProfileShell({thisUser, children, featured, selectedProjectId}: {thisUser: DatedObj<UserObjWithProjects>, children: ReactNode, featured?: boolean, selectedProjectId?: string}) {
+export default function ProfileShell({thisUser, children, featured, selectedProjectId, isSnippet}: {
+    thisUser: DatedObj<UserObjWithProjects>,
+    children: ReactNode,
+    featured?: boolean,
+    selectedProjectId?: string,
+    isSnippet?: boolean,
+}) {
     const featuredProjects = thisUser.projectsArr.filter(d => thisUser.featuredProjects.includes(d._id));
     const thisProject = selectedProjectId && thisUser.projectsArr.find(d => d._id === selectedProjectId);
 
@@ -69,6 +75,11 @@ export default function ProfileShell({thisUser, children, featured, selectedProj
                                 <UpInlineButton href={`/@${thisUser.username}/${thisProject.urlName}`} light={true}>
                                     {thisProject.name}
                                 </UpInlineButton>
+                            </>
+                        )}
+                        {isSnippet && (
+                            <>
+                                <span className="mx-2 up-gray-300">/ Snippet</span>
                             </>
                         )}
                     </div>

--- a/components/ProfileShell.tsx
+++ b/components/ProfileShell.tsx
@@ -15,7 +15,7 @@ export default function ProfileShell({thisUser, children, featured, selectedProj
 
     const SidebarContents = (props: {mobile?: boolean}) => (
         <div className={`overflow-y-auto -mx-4 px-4 ${props.mobile ? "" : "pt-12"}`} style={{
-            height: props.mobile ? "calc(100vh - 3rem - 64px)" : "calc(100vh - 3rem)"
+            height: props.mobile ? "calc(100vh - 4rem - 64px)" : "calc(100vh - 4rem)"
         }}>
             <Link href={`/@${thisUser.username}`}>
                 <a>

--- a/components/ProjectDashboardDropdown.tsx
+++ b/components/ProjectDashboardDropdown.tsx
@@ -1,0 +1,13 @@
+import {FiChevronDown} from "react-icons/fi";
+import MoreMenuItem from "./more-menu-item";
+
+export default function ProjectDashboardDropdown({projectId, className}: {projectId: string, className?: string}) {
+    return (
+        <button className={`up-hover-button relative h-8 px-2 ${className || ""}`}>
+            <FiChevronDown className="text-sm cursor-pointer up-gray-300"/>
+            <div className="up-hover-dropdown mt-8">
+                <MoreMenuItem text="Project dashboard" href={`/projects/${projectId}`}/>
+            </div>
+        </button>
+    );
+}

--- a/components/ProjectSnippetBrowser.tsx
+++ b/components/ProjectSnippetBrowser.tsx
@@ -1,0 +1,59 @@
+import {DatedObj, SnippetObjGraph} from "../utils/types";
+import {format} from "date-fns";
+import SnippetItemCardReadOnly from "./SnippetItemCardReadOnly";
+import PaginationBar from "./PaginationBar";
+import Skeleton from "react-loading-skeleton";
+import React, {Dispatch, SetStateAction, useState} from "react";
+import Link from "next/link";
+
+export default function ProjectSnippetBrowser({snippets, isOwner, snippetPage, setSnippetPage, projectId}: {
+    snippets: {snippets: DatedObj<SnippetObjGraph>[], count: number} | undefined,
+    isOwner?: boolean,
+    snippetPage: number,
+    setSnippetPage: Dispatch<SetStateAction<number>>,
+    projectId?: string,
+}) {
+    const snippetsReady = snippets && snippets.snippets;
+
+    return (
+        <div className="mb-12">
+            <p className="mb-4 up-gray-400">
+                {isOwner ? (
+                    <span>You are viewing this {projectId ? "project" : "user"}'s snippets as a public visitor. To see all your snippets, go to {
+                        projectId ? (
+                            <Link href={`/projects/${projectId}`}>
+                                <a className="underline">project dashboard</a>
+                            </Link>
+                        ) : "the dashboards of your projects"
+                    }.</span>
+                ) : (
+                    <span>Snippets are source notes that eventually turn into posts.</span>
+                )}
+            </p>
+            {snippetsReady ? !!snippets.snippets.length ? (
+                <div className="mb-12 -mt-8">
+                    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                        {snippets.snippets.map((item, i, a) => (
+                            <>
+                                {(i === 0 || format(new Date(item.createdAt), "yyyy-MM-dd") !== format(new Date(a[i - 1].createdAt), "yyyy-MM-dd")) && (
+                                    <p className="up-ui-title mt-12 pb-4 md:col-span-2 xl:col-span-3">{format(new Date(item.createdAt), "EEEE, MMMM d")}</p>
+                                )}
+                                <SnippetItemCardReadOnly snippet={item}/>
+                            </>
+                        ))}
+                    </div>
+                    <PaginationBar
+                        page={snippetPage}
+                        count={snippets.count}
+                        label="snippet"
+                        setPage={setSnippetPage}
+                    />
+                </div>
+            ) : (
+                <p>No public snippets have been published {projectId ? "in this project" : "by this user"} yet.</p>
+            ) : (
+                <Skeleton count={1} className="h-32 w-full mt-12"/>
+            )}
+        </div>
+    );
+}

--- a/components/ProjectSnippetBrowser.tsx
+++ b/components/ProjectSnippetBrowser.tsx
@@ -38,7 +38,7 @@ export default function ProjectSnippetBrowser({snippets, isOwner, snippetPage, s
                                 {(i === 0 || format(new Date(item.createdAt), "yyyy-MM-dd") !== format(new Date(a[i - 1].createdAt), "yyyy-MM-dd")) && (
                                     <p className="up-ui-title mt-12 pb-4 md:col-span-2 xl:col-span-3">{format(new Date(item.createdAt), "EEEE, MMMM d")}</p>
                                 )}
-                                <SnippetItemCardReadOnly snippet={item}/>
+                                <SnippetItemCardReadOnly snippet={item} showProject={!projectId}/>
                             </>
                         ))}
                     </div>

--- a/components/ProjectSnippetBrowser.tsx
+++ b/components/ProjectSnippetBrowser.tsx
@@ -5,6 +5,7 @@ import PaginationBar from "./PaginationBar";
 import Skeleton from "react-loading-skeleton";
 import React, {Dispatch, SetStateAction, useState} from "react";
 import Link from "next/link";
+import {snippetsExplainer} from "../utils/copy";
 
 export default function ProjectSnippetBrowser({snippets, isOwner, snippetPage, setSnippetPage, projectId}: {
     snippets: {snippets: DatedObj<SnippetObjGraph>[], count: number} | undefined,
@@ -27,7 +28,7 @@ export default function ProjectSnippetBrowser({snippets, isOwner, snippetPage, s
                         ) : "the dashboards of your projects"
                     }.</span>
                 ) : (
-                    <span>Snippets are source notes that eventually turn into posts.</span>
+                    <span>{snippetsExplainer}</span>
                 )}
             </p>
             {snippetsReady ? !!snippets.snippets.length ? (

--- a/components/SnippetItemCard.tsx
+++ b/components/SnippetItemCard.tsx
@@ -64,19 +64,21 @@ export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIt
                     <p className="up-gray-500">
                         {format(new Date(snippet.createdAt), showFullDate ? "MMMM d, yyyy 'at' h:mm a" : "h:mm a")}
                     </p>
-                    {hasLinkedPosts && (
-                        <div className="ml-auto flex items-center">
-                            {snippet.privacy === "private" && (
-                                <div className="mr-6">
-                                    <FiLock/>
-                                </div>
-                            )}
-                            <FiLink/>
-                            <span className="ml-2">{snippet.linkedPosts.length}</span>
-                        </div>
-                    )}
+                    <div className="ml-auto flex items-center">
+                        {snippet.privacy === "private" && (
+                            <div className={hasLinkedPosts ? "mr-6" : ""}>
+                                <FiLock className="up-gray-300"/>
+                            </div>
+                        )}
+                        {hasLinkedPosts && (
+                            <>
+                                <FiLink/>
+                                <span className="ml-2">{snippet.linkedPosts.length}</span>
+                            </>
+                        )}
+                    </div>
                     {hasTags && (
-                        <div className={`flex items-center ${hasLinkedPosts ? "" : "ml-auto"}`}>
+                        <div className={`flex items-center ${(hasLinkedPosts || snippet.privacy === "private") ? "ml-2" : "ml-auto"}`}>
                             {snippet.tags.map(tag => (
                                 <button className="up-gray-400 font-bold ml-2" onClick={() => setTagsQuery([tag])}>
                                     #{tag}
@@ -99,7 +101,7 @@ export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIt
                     ))}
                     {session.userId !== snippet.userId && (
                         <>
-                            <span className="ml-auto mr-2 up-gray-300">by</span>
+                            <span className={`${hasTags ? "ml-6" : "ml-auto"} mr-2 up-gray-300`}>by</span>
                             <UpInlineButton href={`/@${snippet.authorArr[0].username}`}>
                                 <div className="flex items-center">
                                     <img

--- a/components/SnippetItemCard.tsx
+++ b/components/SnippetItemCard.tsx
@@ -8,6 +8,7 @@ import SnippetItemInner from "./SnippetItemInner";
 import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
 import {useSession} from "next-auth/client";
 import UpInlineButton from "./style/UpInlineButton";
+import Link from "next/link";
 
 export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIteration, setStatsIter, statsIter, availableTags, addNewTags, selectedSnippetIds, setSelectedSnippetIds, showFullDate}: {
     snippet: DatedObj<SnippetObjGraph>,
@@ -69,7 +70,11 @@ export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIt
                             {snippet.privacy === "private" ? (
                                 <FiLock className="up-gray-300"/>
                             ) : (
-                                <FiGlobe/>
+                                <Link href={`/@${snippet.authorArr[0].username}/s/${snippet._id}`}>
+                                    <a>
+                                        <FiGlobe/>
+                                    </a>
+                                </Link>
                             )}
                         </div>
                         {hasLinkedPosts && (
@@ -96,7 +101,11 @@ export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIt
                         {snippet.privacy === "private" ? (
                             <FiLock className="up-gray-300"/>
                         ) : (
-                            <FiGlobe/>
+                            <Link href={`/@${snippet.authorArr[0].username}/s/${snippet._id}`}>
+                                <a>
+                                    <FiGlobe/>
+                                </a>
+                            </Link>
                         )}
                     </div>
                     <p className="up-gray-400">Posted on {format(new Date(snippet.createdAt), "MMMM d, yyyy 'at' h:mm a")}</p>

--- a/components/SnippetItemCard.tsx
+++ b/components/SnippetItemCard.tsx
@@ -2,7 +2,7 @@ import {DatedObj, SnippetObjGraph} from "../utils/types";
 import SlateReadOnly from "./SlateReadOnly";
 import {format} from "date-fns";
 import React, {Dispatch, SetStateAction, useState} from "react";
-import {FiCheck, FiCheckCircle, FiLink} from "react-icons/fi";
+import {FiCheck, FiCheckCircle, FiLink, FiLock} from "react-icons/fi";
 import UpModal from "./up-modal";
 import SnippetItemInner from "./SnippetItemInner";
 import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
@@ -66,6 +66,11 @@ export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIt
                     </p>
                     {hasLinkedPosts && (
                         <div className="ml-auto flex items-center">
+                            {snippet.privacy === "private" && (
+                                <div className="mr-6">
+                                    <FiLock/>
+                                </div>
+                            )}
                             <FiLink/>
                             <span className="ml-2">{snippet.linkedPosts.length}</span>
                         </div>

--- a/components/SnippetItemCard.tsx
+++ b/components/SnippetItemCard.tsx
@@ -2,7 +2,7 @@ import {DatedObj, SnippetObjGraph} from "../utils/types";
 import SlateReadOnly from "./SlateReadOnly";
 import {format} from "date-fns";
 import React, {Dispatch, SetStateAction, useState} from "react";
-import {FiCheck, FiCheckCircle, FiLink, FiLock} from "react-icons/fi";
+import {FiCheck, FiCheckCircle, FiGlobe, FiLink, FiLock} from "react-icons/fi";
 import UpModal from "./up-modal";
 import SnippetItemInner from "./SnippetItemInner";
 import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
@@ -65,11 +65,13 @@ export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIt
                         {format(new Date(snippet.createdAt), showFullDate ? "MMMM d, yyyy 'at' h:mm a" : "h:mm a")}
                     </p>
                     <div className="ml-auto flex items-center">
-                        {snippet.privacy === "private" && (
-                            <div className={hasLinkedPosts ? "mr-6" : ""}>
+                        <div className={hasLinkedPosts ? "mr-6" : ""}>
+                            {snippet.privacy === "private" ? (
                                 <FiLock className="up-gray-300"/>
-                            </div>
-                        )}
+                            ) : (
+                                <FiGlobe/>
+                            )}
+                        </div>
                         {hasLinkedPosts && (
                             <>
                                 <FiLink/>
@@ -78,7 +80,7 @@ export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIt
                         )}
                     </div>
                     {hasTags && (
-                        <div className={`flex items-center ${(hasLinkedPosts || snippet.privacy === "private") ? "ml-2" : "ml-auto"}`}>
+                        <div className={`flex items-center ml-2`}>
                             {snippet.tags.map(tag => (
                                 <button className="up-gray-400 font-bold ml-2" onClick={() => setTagsQuery([tag])}>
                                     #{tag}
@@ -90,6 +92,13 @@ export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIt
             </div>
             <UpModal isOpen={modalOpen} setIsOpen={setModalOpen} wide={true}>
                 <div className="md:flex items-center py-4 bg-white">
+                    <div className="mr-4" title={`Privacy: ${snippet.privacy}`}>
+                        {snippet.privacy === "private" ? (
+                            <FiLock className="up-gray-300"/>
+                        ) : (
+                            <FiGlobe/>
+                        )}
+                    </div>
                     <p className="up-gray-400">Posted on {format(new Date(snippet.createdAt), "MMMM d, yyyy 'at' h:mm a")}</p>
                     {hasTags && snippet.tags.map((tag, i) => (
                         <button

--- a/components/SnippetItemCard.tsx
+++ b/components/SnippetItemCard.tsx
@@ -2,13 +2,13 @@ import {DatedObj, SnippetObjGraph} from "../utils/types";
 import SlateReadOnly from "./SlateReadOnly";
 import {format} from "date-fns";
 import React, {Dispatch, SetStateAction, useState} from "react";
-import {FiCheck, FiCheckCircle, FiGlobe, FiLink, FiLock} from "react-icons/fi";
+import {FiCheck, FiGlobe, FiLink, FiLock} from "react-icons/fi";
 import UpModal from "./up-modal";
 import SnippetItemInner from "./SnippetItemInner";
 import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
 import {useSession} from "next-auth/client";
-import UpInlineButton from "./style/UpInlineButton";
 import Link from "next/link";
+import SnippetModalShell from "./SnippetModalShell";
 
 export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIteration, setStatsIter, statsIter, availableTags, addNewTags, selectedSnippetIds, setSelectedSnippetIds, showFullDate}: {
     snippet: DatedObj<SnippetObjGraph>,
@@ -96,44 +96,7 @@ export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIt
                 </div>
             </div>
             <UpModal isOpen={modalOpen} setIsOpen={setModalOpen} wide={true}>
-                <div className="md:flex items-center py-4 bg-white">
-                    <div className="mr-4" title={`Privacy: ${snippet.privacy}`}>
-                        {snippet.privacy === "private" ? (
-                            <FiLock className="up-gray-300"/>
-                        ) : (
-                            <Link href={`/@${snippet.authorArr[0].username}/s/${snippet._id}`}>
-                                <a>
-                                    <FiGlobe/>
-                                </a>
-                            </Link>
-                        )}
-                    </div>
-                    <p className="up-gray-400">Posted on {format(new Date(snippet.createdAt), "MMMM d, yyyy 'at' h:mm a")}</p>
-                    {hasTags && snippet.tags.map((tag, i) => (
-                        <button
-                            className={`up-gray-400 font-bold ${i === 0 ? "md:ml-auto" : "ml-2"}`}
-                            onClick={() => setTagsQuery([tag])}
-                        >
-                            #{tag}
-                        </button>
-                    ))}
-                    {session.userId !== snippet.userId && (
-                        <>
-                            <span className={`${hasTags ? "ml-6" : "ml-auto"} mr-2 up-gray-300`}>by</span>
-                            <UpInlineButton href={`/@${snippet.authorArr[0].username}`}>
-                                <div className="flex items-center">
-                                    <img
-                                        src={snippet.authorArr[0].image}
-                                        alt={`Profile picture of ${snippet.authorArr[0].name}`}
-                                        className="w-6 h-6 rounded-full mr-2 opacity-75"
-                                    />
-                                    <span>{snippet.authorArr[0].name}</span>
-                                </div>
-                            </UpInlineButton>
-                        </>
-                    )}
-                </div>
-                <div style={{maxHeight: "calc(100vh - 240px)", minHeight: 300, overflowY: "auto"}} className="-mx-4 px-4 relative">
+                <SnippetModalShell snippet={snippet} setTagsQuery={setTagsQuery}>
                     <SnippetItemInner
                         snippet={snippet}
                         iteration={iteration}
@@ -145,7 +108,7 @@ export default function SnippetItemCard({snippet, setTagsQuery, iteration, setIt
                         setTagsQuery={setTagsQuery}
                         setOpen={setModalOpen}
                     />
-                </div>
+                </SnippetModalShell>
             </UpModal>
         </>
     );

--- a/components/SnippetItemCardReadOnly.tsx
+++ b/components/SnippetItemCardReadOnly.tsx
@@ -9,9 +9,10 @@ import {useSession} from "next-auth/client";
 import UpInlineButton from "./style/UpInlineButton";
 import Link from "next/link";
 
-export default function SnippetItemCardReadOnly({snippet, showFullDate}: {
+export default function SnippetItemCardReadOnly({snippet, showFullDate, showProject}: {
     snippet: DatedObj<SnippetObjGraph>,
     showFullDate?: boolean,
+    showProject?: boolean,
 }) {
     const [session, loading] = useSession();
     const [modalOpen, setModalOpen] = useState<boolean>(false);
@@ -26,8 +27,18 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate}: {
         >
             {isPublic ? (
                 <>
+                    {showProject && (
+                        <div className="h-8 flex items-center">
+                            <span className="mr-1 up-gray-400">In:</span>
+                            <UpInlineButton
+                                href={`/@${snippet.authorArr[0].username}/${snippet.projectArr[0].urlName}`}
+                            >
+                                {snippet.projectArr[0].name}
+                            </UpInlineButton>
+                        </div>
+                    )}
                     <button
-                        className="h-36 overflow-hidden text-xs relative -mx-4 px-4 text-left block -mt-2"
+                        className={`${showProject ? "h-28" : "h-36"} overflow-hidden text-xs relative -mx-4 px-4 text-left block -mt-2`}
                         style={{width: "calc(100% + 2rem)"}}
                         onClick={() => setModalOpen(true)}
                     >

--- a/components/SnippetItemCardReadOnly.tsx
+++ b/components/SnippetItemCardReadOnly.tsx
@@ -2,13 +2,15 @@ import {DatedObj, SnippetObjGraph} from "../utils/types";
 import SlateReadOnly from "./SlateReadOnly";
 import {format} from "date-fns";
 import React, {useState} from "react";
-import {FiExternalLink, FiGlobe, FiLink, FiLock} from "react-icons/fi";
+import {FiGlobe, FiLink, FiLock} from "react-icons/fi";
 import UpModal from "./up-modal";
 import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
 import {useSession} from "next-auth/client";
 import UpInlineButton from "./style/UpInlineButton";
 import Link from "next/link";
 import {useRouter} from "next/router";
+import SnippetModalReadArea from "./SnippetModalReadArea";
+import SnippetModalShell from "./SnippetModalShell";
 
 export default function SnippetItemCardReadOnly({snippet, showFullDate, showProject}: {
     snippet: DatedObj<SnippetObjGraph>,
@@ -88,79 +90,9 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate, showProj
                     <UpModal isOpen={modalOpen} setIsOpen={(d: boolean) => {
                         setModalOpen(d);
                     }} wide={true}>
-                        <div className="md:flex items-center py-4 bg-white">
-                            <p className="up-gray-400">Posted on {format(new Date(snippet.createdAt), "MMMM d, yyyy 'at' h:mm a")}</p>
-                            {hasTags && snippet.tags.map((tag, i) => (
-                                <button
-                                    className={`up-gray-400 font-bold ${i === 0 ? "md:ml-auto" : "ml-2"}`}
-                                    onClick={() => null} // fix tag search later
-                                >
-                                    #{tag}
-                                </button>
-                            ))}
-                            {session && (session.userId !== snippet.userId) && (
-                                <>
-                                    <span className="ml-auto mr-2 up-gray-300">by</span>
-                                    <UpInlineButton href={`/@${snippet.authorArr[0].username}`}>
-                                        <div className="flex items-center">
-                                            <img
-                                                src={snippet.authorArr[0].image}
-                                                alt={`Profile picture of ${snippet.authorArr[0].name}`}
-                                                className="w-6 h-6 rounded-full mr-2 opacity-75"
-                                            />
-                                            <span>{snippet.authorArr[0].name}</span>
-                                        </div>
-                                    </UpInlineButton>
-                                </>
-                            )}
-                            {snippet.privacy === "public" && (
-                                <UpInlineButton
-                                    href={`/@${snippet.authorArr[0].username}/s/${snippet._id}`}
-                                    className={"ml-auto"}
-                                >
-                                    <div className="flex items-center">
-                                        <span className="mr-2">Open as page</span>
-                                        <FiExternalLink/>
-                                    </div>
-                                </UpInlineButton>
-                            )}
-                        </div>
-                        <div style={{maxHeight: "calc(100vh - 240px)", minHeight: 300, overflowY: "auto"}} className="-mx-4 px-4 relative">
-                            <div className="flex">
-                                <div className="w-full" style={{minWidth: 0}}>
-                                    {snippet.url && (
-                                        <SnippetItemLinkPreview snippet={snippet}/>
-                                    )}
-                                    <div className={`content prose break-words`}>
-                                        <SlateReadOnly nodes={snippet.slateBody}/>
-                                    </div>
-                                    {!!snippet.linkArr.length && (
-                                        <>
-                                            <hr className="mb-8 mt-4"/>
-                                            <p className="up-ui-title">Linked resources ({snippet.linkArr.length}):</p>
-                                            {snippet.linkArr.map(d => (
-                                                <div className="my-2">
-                                                    <SnippetItemLinkPreview url={d.targetUrl}/>
-                                                </div>
-                                            ))}
-                                        </>
-                                    )}
-                                </div>
-                            </div>
-                            {!!snippet.linkedPosts.length && (
-                                <div className="opacity-50 hover:opacity-100 transition pb-8">
-                                    <hr className="mb-8 mt-4"/>
-                                    <p className="up-ui-title">Linked posts ({snippet.linkedPosts.length}):</p>
-                                    {snippet.linkedPostsArr.map(d => (
-                                        <Link href={`/@${snippet.authorArr[0].username}/p/${d.urlName}`}>
-                                            <a className="underline my-2 block">
-                                                {d.title}
-                                            </a>
-                                        </Link>
-                                    ))}
-                                </div>
-                            )}
-                        </div>
+                        <SnippetModalShell snippet={snippet}>
+                            <SnippetModalReadArea snippet={snippet}/>
+                        </SnippetModalShell>
                     </UpModal>
                 </>
             ) : (

--- a/components/SnippetItemCardReadOnly.tsx
+++ b/components/SnippetItemCardReadOnly.tsx
@@ -8,12 +8,14 @@ import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
 import {useSession} from "next-auth/client";
 import UpInlineButton from "./style/UpInlineButton";
 import Link from "next/link";
+import {useRouter} from "next/router";
 
 export default function SnippetItemCardReadOnly({snippet, showFullDate, showProject}: {
     snippet: DatedObj<SnippetObjGraph>,
     showFullDate?: boolean,
     showProject?: boolean,
 }) {
+    const router = useRouter();
     const [session, loading] = useSession();
     const [modalOpen, setModalOpen] = useState<boolean>(false);
 
@@ -40,7 +42,12 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate, showProj
                     <button
                         className={`${showProject ? "h-28" : "h-36"} overflow-hidden text-xs relative -mx-4 px-4 text-left block -mt-2`}
                         style={{width: "calc(100% + 2rem)"}}
-                        onClick={() => setModalOpen(true)}
+                        onClick={() => {
+                            setModalOpen(true);
+                            setTimeout(() => {
+                                router.push(router.route, decodeURIComponent(router.asPath) + `?snippetId=${snippet._id}`, {shallow: true, scroll: false});
+                            }, 100);
+                        }}
                     >
                         <SnippetItemLinkPreview snippet={snippet} small={true}/>
                         <div className="prose opacity-75 select-none w-full">
@@ -77,7 +84,12 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate, showProj
                             )}
                         </div>
                     </div>
-                    <UpModal isOpen={modalOpen} setIsOpen={setModalOpen} wide={true}>
+                    <UpModal isOpen={modalOpen} setIsOpen={(d: boolean) => {
+                        setModalOpen(d);
+                        setTimeout(() => {
+                            router.push(router.route, decodeURIComponent(router.asPath.split("?")[0]), {shallow: true, scroll: false});
+                        }, 100);
+                    }} wide={true}>
                         <div className="md:flex items-center py-4 bg-white">
                             <p className="up-gray-400">Posted on {format(new Date(snippet.createdAt), "MMMM d, yyyy 'at' h:mm a")}</p>
                             {hasTags && snippet.tags.map((tag, i) => (

--- a/components/SnippetItemCardReadOnly.tsx
+++ b/components/SnippetItemCardReadOnly.tsx
@@ -2,7 +2,7 @@ import {DatedObj, SnippetObjGraph} from "../utils/types";
 import SlateReadOnly from "./SlateReadOnly";
 import {format} from "date-fns";
 import React, {useState} from "react";
-import {FiLink, FiLock} from "react-icons/fi";
+import {FiGlobe, FiLink, FiLock} from "react-icons/fi";
 import UpModal from "./up-modal";
 import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
 import {useSession} from "next-auth/client";
@@ -51,11 +51,13 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate}: {
                             {format(new Date(snippet.createdAt), showFullDate ? "MMMM d, yyyy 'at' h:mm a" : "h:mm a")}
                         </p>
                         <div className="ml-auto flex items-center">
-                            {snippet.privacy === "private" && (
-                                <div className="mr-6">
-                                    <FiLock className="up-gray-300"/>
-                                </div>
-                            )}
+                            <div className={"up-gray-300 " + (hasLinkedPosts ? "mr-6" : "")}>
+                                {snippet.privacy === "private" ? (
+                                    <FiLock/>
+                                ) : (
+                                    <FiGlobe/>
+                                )}
+                            </div>
                             {hasLinkedPosts && (
                                 <>
                                     <FiLink/>

--- a/components/SnippetItemCardReadOnly.tsx
+++ b/components/SnippetItemCardReadOnly.tsx
@@ -40,7 +40,7 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate}: {
                         }}/>
                     </button>
                     <div className="flex items-center mt-4 text-sm">
-                        {session && session.userId !== snippet.userId && (
+                        {session && (session.userId !== snippet.userId) && (
                             <img
                                 src={snippet.authorArr[0].image}
                                 alt={`Profile picture of ${snippet.authorArr[0].name}`}
@@ -77,7 +77,7 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate}: {
                                     #{tag}
                                 </button>
                             ))}
-                            {session.userId !== snippet.userId && (
+                            {session && (session.userId !== snippet.userId) && (
                                 <>
                                     <span className="ml-auto mr-2 up-gray-300">by</span>
                                     <UpInlineButton href={`/@${snippet.authorArr[0].username}`}>

--- a/components/SnippetItemCardReadOnly.tsx
+++ b/components/SnippetItemCardReadOnly.tsx
@@ -50,17 +50,19 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate}: {
                         <p className="up-gray-500">
                             {format(new Date(snippet.createdAt), showFullDate ? "MMMM d, yyyy 'at' h:mm a" : "h:mm a")}
                         </p>
-                        {hasLinkedPosts && (
-                            <div className="ml-auto flex items-center">
-                                {snippet.privacy === "private" && (
-                                    <div className="mr-6">
-                                        <FiLock/>
-                                    </div>
-                                )}
-                                <FiLink/>
-                                <span className="ml-2">{snippet.linkedPosts.length}</span>
-                            </div>
-                        )}
+                        <div className="ml-auto flex items-center">
+                            {snippet.privacy === "private" && (
+                                <div className="mr-6">
+                                    <FiLock className="up-gray-300"/>
+                                </div>
+                            )}
+                            {hasLinkedPosts && (
+                                <>
+                                    <FiLink/>
+                                    <span className="ml-2">{snippet.linkedPosts.length}</span>
+                                </>
+                            )}
+                        </div>
                     </div>
                     <UpModal isOpen={modalOpen} setIsOpen={setModalOpen} wide={true}>
                         <div className="md:flex items-center py-4 bg-white">

--- a/components/SnippetItemCardReadOnly.tsx
+++ b/components/SnippetItemCardReadOnly.tsx
@@ -2,7 +2,7 @@ import {DatedObj, SnippetObjGraph} from "../utils/types";
 import SlateReadOnly from "./SlateReadOnly";
 import {format} from "date-fns";
 import React, {useState} from "react";
-import {FiGlobe, FiLink, FiLock} from "react-icons/fi";
+import {FiExternalLink, FiGlobe, FiLink, FiLock} from "react-icons/fi";
 import UpModal from "./up-modal";
 import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
 import {useSession} from "next-auth/client";
@@ -69,11 +69,15 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate, showProj
                             {format(new Date(snippet.createdAt), showFullDate ? "MMMM d, yyyy 'at' h:mm a" : "h:mm a")}
                         </p>
                         <div className="ml-auto flex items-center">
-                            <div className={"up-gray-300 " + (hasLinkedPosts ? "mr-6" : "")}>
+                            <div className={hasLinkedPosts ? "mr-6" : ""}>
                                 {snippet.privacy === "private" ? (
-                                    <FiLock/>
+                                    <FiLock className="up-gray-300"/>
                                 ) : (
-                                    <FiGlobe/>
+                                    <Link href={`/@${snippet.authorArr[0].username}/s/${snippet._id}`}>
+                                        <a>
+                                            <FiGlobe/>
+                                        </a>
+                                    </Link>
                                 )}
                             </div>
                             {hasLinkedPosts && (
@@ -114,6 +118,17 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate, showProj
                                         </div>
                                     </UpInlineButton>
                                 </>
+                            )}
+                            {snippet.privacy === "public" && (
+                                <UpInlineButton
+                                    href={`/@${snippet.authorArr[0].username}/s/${snippet._id}`}
+                                    className={"ml-auto"}
+                                >
+                                    <div className="flex items-center">
+                                        <span className="mr-2">Open as page</span>
+                                        <FiExternalLink/>
+                                    </div>
+                                </UpInlineButton>
                             )}
                         </div>
                         <div style={{maxHeight: "calc(100vh - 240px)", minHeight: 300, overflowY: "auto"}} className="-mx-4 px-4 relative">

--- a/components/SnippetItemCardReadOnly.tsx
+++ b/components/SnippetItemCardReadOnly.tsx
@@ -1,0 +1,143 @@
+import {DatedObj, SnippetObjGraph} from "../utils/types";
+import SlateReadOnly from "./SlateReadOnly";
+import {format} from "date-fns";
+import React, {useState} from "react";
+import {FiLink, FiLock} from "react-icons/fi";
+import UpModal from "./up-modal";
+import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
+import {useSession} from "next-auth/client";
+import UpInlineButton from "./style/UpInlineButton";
+import Link from "next/link";
+
+export default function SnippetItemCardReadOnly({snippet, showFullDate}: {
+    snippet: DatedObj<SnippetObjGraph>,
+    showFullDate?: boolean,
+}) {
+    const [session, loading] = useSession();
+    const [modalOpen, setModalOpen] = useState<boolean>(false);
+
+    const hasLinkedPosts = snippet.linkedPosts && !!snippet.linkedPosts.length;
+    const hasTags = snippet.tags && !!snippet.tags.length;
+    const isPublic = snippet.privacy === "public" || (session && session.userId === snippet.userId);
+
+    return (
+        <div
+            className={`relative bg-white border up-border-gray-200 rounded-lg p-4 h-52 ${isPublic ? "hover:shadow-lg hover:up-border-gray-500" : ""} transition up-hover-parent`}
+        >
+            {isPublic ? (
+                <>
+                    <button
+                        className="h-36 overflow-hidden text-xs relative -mx-4 px-4 text-left block -mt-2"
+                        style={{width: "calc(100% + 2rem)"}}
+                        onClick={() => setModalOpen(true)}
+                    >
+                        <SnippetItemLinkPreview snippet={snippet} small={true}/>
+                        <div className="prose opacity-75 select-none w-full">
+                            <SlateReadOnly nodes={snippet.slateBody}/>
+                        </div>
+                        <div className="absolute top-0 left-0 h-full w-full pointer-events-none" style={{
+                            boxShadow: "rgb(255, 255, 255) 0px -40px 40px -10px inset",
+                        }}/>
+                    </button>
+                    <div className="flex items-center mt-4 text-sm">
+                        {session && session.userId !== snippet.userId && (
+                            <img
+                                src={snippet.authorArr[0].image}
+                                alt={`Profile picture of ${snippet.authorArr[0].name}`}
+                                className="w-6 h-6 rounded-full mr-4 opacity-75"
+                            />
+                        )}
+                        <p className="up-gray-500">
+                            {format(new Date(snippet.createdAt), showFullDate ? "MMMM d, yyyy 'at' h:mm a" : "h:mm a")}
+                        </p>
+                        {hasLinkedPosts && (
+                            <div className="ml-auto flex items-center">
+                                {snippet.privacy === "private" && (
+                                    <div className="mr-6">
+                                        <FiLock/>
+                                    </div>
+                                )}
+                                <FiLink/>
+                                <span className="ml-2">{snippet.linkedPosts.length}</span>
+                            </div>
+                        )}
+                    </div>
+                    <UpModal isOpen={modalOpen} setIsOpen={setModalOpen} wide={true}>
+                        <div className="md:flex items-center py-4 bg-white">
+                            <p className="up-gray-400">Posted on {format(new Date(snippet.createdAt), "MMMM d, yyyy 'at' h:mm a")}</p>
+                            {hasTags && snippet.tags.map((tag, i) => (
+                                <button
+                                    className={`up-gray-400 font-bold ${i === 0 ? "md:ml-auto" : "ml-2"}`}
+                                    onClick={() => null} // fix tag search later
+                                >
+                                    #{tag}
+                                </button>
+                            ))}
+                            {session.userId !== snippet.userId && (
+                                <>
+                                    <span className="ml-auto mr-2 up-gray-300">by</span>
+                                    <UpInlineButton href={`/@${snippet.authorArr[0].username}`}>
+                                        <div className="flex items-center">
+                                            <img
+                                                src={snippet.authorArr[0].image}
+                                                alt={`Profile picture of ${snippet.authorArr[0].name}`}
+                                                className="w-6 h-6 rounded-full mr-2 opacity-75"
+                                            />
+                                            <span>{snippet.authorArr[0].name}</span>
+                                        </div>
+                                    </UpInlineButton>
+                                </>
+                            )}
+                        </div>
+                        <div style={{maxHeight: "calc(100vh - 240px)", minHeight: 300, overflowY: "auto"}} className="-mx-4 px-4 relative">
+                            <div className="flex">
+                                <div className="w-full" style={{minWidth: 0}}>
+                                    {snippet.url && (
+                                        <SnippetItemLinkPreview snippet={snippet}/>
+                                    )}
+                                    <div className={`content prose break-words`}>
+                                        <SlateReadOnly nodes={snippet.slateBody}/>
+                                    </div>
+                                    {!!snippet.linkArr.length && (
+                                        <>
+                                            <hr className="mb-8 mt-4"/>
+                                            <p className="up-ui-title">Linked resources ({snippet.linkArr.length}):</p>
+                                            {snippet.linkArr.map(d => (
+                                                <div className="my-2">
+                                                    <SnippetItemLinkPreview url={d.targetUrl}/>
+                                                </div>
+                                            ))}
+                                        </>
+                                    )}
+                                </div>
+                            </div>
+                            {!!snippet.linkedPosts.length && (
+                                <div className="opacity-50 hover:opacity-100 transition pb-8">
+                                    <hr className="mb-8 mt-4"/>
+                                    <p className="up-ui-title">Linked posts ({snippet.linkedPosts.length}):</p>
+                                    {snippet.linkedPostsArr.map(d => (
+                                        <Link href={`/@${snippet.authorArr[0].username}/p/${d.urlName}`}>
+                                            <a className="underline my-2 block">
+                                                {d.title}
+                                            </a>
+                                        </Link>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </UpModal>
+                </>
+            ) : (
+                <>
+                    <div className="h-36 flex items-center up-gray-300 font-medium">
+                        <FiLock/>
+                        <p className="ml-2">Private snippet</p>
+                    </div>
+                    <p className="up-gray-500 mt-2">
+                        {format(new Date(snippet.createdAt), showFullDate ? "MMMM d, yyyy 'at' h:mm a" : "h:mm a")}
+                    </p>
+                </>
+            )}
+        </div>
+    );
+}

--- a/components/SnippetItemCardReadOnly.tsx
+++ b/components/SnippetItemCardReadOnly.tsx
@@ -44,9 +44,6 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate, showProj
                         style={{width: "calc(100% + 2rem)"}}
                         onClick={() => {
                             setModalOpen(true);
-                            setTimeout(() => {
-                                router.push(router.route, decodeURIComponent(router.asPath) + `?snippetId=${snippet._id}`, {shallow: true, scroll: false});
-                            }, 100);
                         }}
                     >
                         <SnippetItemLinkPreview snippet={snippet} small={true}/>
@@ -90,9 +87,6 @@ export default function SnippetItemCardReadOnly({snippet, showFullDate, showProj
                     </div>
                     <UpModal isOpen={modalOpen} setIsOpen={(d: boolean) => {
                         setModalOpen(d);
-                        setTimeout(() => {
-                            router.push(router.route, decodeURIComponent(router.asPath.split("?")[0]), {shallow: true, scroll: false});
-                        }, 100);
                     }} wide={true}>
                         <div className="md:flex items-center py-4 bg-white">
                             <p className="up-gray-400">Posted on {format(new Date(snippet.createdAt), "MMMM d, yyyy 'at' h:mm a")}</p>

--- a/components/SnippetItemInner.tsx
+++ b/components/SnippetItemInner.tsx
@@ -58,7 +58,7 @@ export default function SnippetItemInner({snippet, iteration, setIteration, setS
         axios.post("/api/cancel-delete-images", {type: "snippet", id: snippet._id.toString()});
     }
 
-    function onSaveEdit(urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], isSlate?: boolean) {
+    function onSaveEdit(urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], privacy: "public" | "private", isSlate?: boolean) {
         setIsEditLoading(true);
 
         axios.post("/api/snippet", {
@@ -68,6 +68,7 @@ export default function SnippetItemInner({snippet, iteration, setIteration, setS
             tags: tags || [],
             urlName: snippet.urlName,
             isSlate: !!isSlate,
+            privacy: privacy,
         }).then(res => {
             if (res.data.newTags.length) addNewTags(res.data.newTags);
             setIteration(iteration + 1);

--- a/components/SnippetItemInner.tsx
+++ b/components/SnippetItemInner.tsx
@@ -7,13 +7,15 @@ import SlateReadOnly from "./SlateReadOnly";
 import SnippetEditor from "./snippet-editor";
 import MoreMenu from "./more-menu";
 import MoreMenuItem from "./more-menu-item";
-import {FiArrowRightCircle, FiEdit2, FiGlobe, FiLock, FiTrash} from "react-icons/fi";
+import {FiArrowRightCircle, FiEdit2, FiExternalLink, FiGlobe, FiLock, FiTrash} from "react-icons/fi";
 import UpModal from "./up-modal";
 import SpinnerButton from "./spinner-button";
 import ProjectBrowser from "./project-browser";
 import Link from "next/link";
 import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
 import Mousetrap from "mousetrap";
+import SnippetLinkedPosts from "./SnippetLinkedPosts";
+import SnippetModalReadArea from "./SnippetModalReadArea";
 
 export default function SnippetItemInner({snippet, iteration, setIteration, setStatsIter, statsIter, availableTags, addNewTags, isList, setTagsQuery, setOpen}: {
     snippet: DatedObj<SnippetObjGraph>,
@@ -142,6 +144,13 @@ export default function SnippetItemInner({snippet, iteration, setIteration, setS
                     onClick={onTogglePrivacy}
                     disabled={isPrivacyLoading}
                 />
+                {snippet.privacy === "public" && (
+                    <MoreMenuItem
+                        text="Open as page"
+                        icon={<FiExternalLink/>}
+                        href={`/@${snippet.authorArr[0].username}/s/${snippet._id}`}
+                    />
+                )}
                 <MoreMenuItem text="Delete" icon={<FiTrash/>} onClick={() => setIsDeleteOpen(true)}/>
             </MoreMenu>
             <UpModal isOpen={isDeleteOpen} setIsOpen={setIsDeleteOpen}>
@@ -180,55 +189,12 @@ export default function SnippetItemInner({snippet, iteration, setIteration, setS
                     />
                 </>
             ) : (
-                <>
-                    <div className="flex">
-                        <div className="w-full" style={{minWidth: 0}}>
-                            {snippet.url && (
-                                <SnippetItemLinkPreview snippet={snippet}/>
-                            )}
-                            <div className={`${isList ? "" : "content"} prose break-words`}>
-                                <SlateReadOnly nodes={snippet.slateBody}/>
-                            </div>
-                            {!!snippet.linkArr.length && (
-                                <>
-                                    <hr className="mb-8 mt-4"/>
-                                    <p className="up-ui-title">Linked resources ({snippet.linkArr.length}):</p>
-                                    {snippet.linkArr.map(d => (
-                                        <div className="my-2">
-                                            <SnippetItemLinkPreview url={d.targetUrl}/>
-                                        </div>
-                                    ))}
-                                </>
-                            )}
-                        </div>
-                        {session && session.userId === snippet.userId && (
-                            <ThisMoreMenu/>
-                        )}
-                    </div>
-                    {isList && (
-                        <div className="flex mt-4">
-                            {snippet.tags && snippet.tags.map(tag => (
-                                <button
-                                    className="font-bold opacity-50 mr-2"
-                                    onClick={() => setTagsQuery([tag])}
-                                >#{tag}</button>
-                            ))}
-                        </div>
-                    )}
-                    {!!snippet.linkedPosts.length && (
-                        <div className="opacity-50 hover:opacity-100 transition pb-8">
-                            <hr className="mb-8 mt-4"/>
-                            <p className="up-ui-title">Linked posts ({snippet.linkedPosts.length}):</p>
-                            {snippet.linkedPostsArr.map(d => (
-                                <Link href={`/@${snippet.authorArr[0].username}/p/${d.urlName}`}>
-                                    <a className="underline my-2 block">
-                                        {d.title}
-                                    </a>
-                                </Link>
-                            ))}
-                        </div>
-                    )}
-                </>
+                <SnippetModalReadArea
+                    snippet={snippet}
+                    thisMoreMenu={<ThisMoreMenu/>}
+                    isList={isList}
+                    setTagsQuery={setTagsQuery}
+                />
             )}
         </>
     )

--- a/components/SnippetItemInner.tsx
+++ b/components/SnippetItemInner.tsx
@@ -7,7 +7,7 @@ import SlateReadOnly from "./SlateReadOnly";
 import SnippetEditor from "./snippet-editor";
 import MoreMenu from "./more-menu";
 import MoreMenuItem from "./more-menu-item";
-import {FiArrowRightCircle, FiEdit2, FiTrash} from "react-icons/fi";
+import {FiArrowRightCircle, FiEdit2, FiGlobe, FiLock, FiTrash} from "react-icons/fi";
 import UpModal from "./up-modal";
 import SpinnerButton from "./spinner-button";
 import ProjectBrowser from "./project-browser";
@@ -33,6 +33,7 @@ export default function SnippetItemInner({snippet, iteration, setIteration, setS
     const [isEdit, setIsEdit] = useState<boolean>(false);
     const [isMove, setIsMove] = useState<boolean>(false);
     const [isEditLoading, setIsEditLoading] = useState<boolean>(false);
+    const [isPrivacyLoading, setIsPrivacyLoading] = useState<boolean>(false);
 
     function onDelete() {
         setIsLoading(true);
@@ -58,7 +59,7 @@ export default function SnippetItemInner({snippet, iteration, setIteration, setS
         axios.post("/api/cancel-delete-images", {type: "snippet", id: snippet._id.toString()});
     }
 
-    function onSaveEdit(urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], privacy: "public" | "private", isSlate?: boolean) {
+    function onSaveEdit(urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], isSlate?: boolean) {
         setIsEditLoading(true);
 
         axios.post("/api/snippet", {
@@ -68,7 +69,6 @@ export default function SnippetItemInner({snippet, iteration, setIteration, setS
             tags: tags || [],
             urlName: snippet.urlName,
             isSlate: !!isSlate,
-            privacy: privacy,
         }).then(res => {
             if (res.data.newTags.length) addNewTags(res.data.newTags);
             setIteration(iteration + 1);
@@ -90,6 +90,22 @@ export default function SnippetItemInner({snippet, iteration, setIteration, setS
             if (setOpen) setOpen(false);
         }).catch(e => {
             setIsLoading(false);
+            console.log(e);
+        });
+    }
+
+    function onTogglePrivacy() {
+        setIsPrivacyLoading(true);
+
+        axios.post("/api/snippet", {
+            id: snippet._id,
+            privacy: snippet.privacy === "public" ? "private" : "public",
+        }).then(() => {
+            setIteration(iteration + 1);
+            setIsPrivacyLoading(false);
+            if (setOpen) setOpen(false);
+        }).catch(e => {
+            setIsPrivacyLoading(false);
             console.log(e);
         });
     }
@@ -120,6 +136,12 @@ export default function SnippetItemInner({snippet, iteration, setIteration, setS
             <MoreMenu>
                 <MoreMenuItem text="Edit (e)" icon={<FiEdit2/>} onClick={() => setIsEdit(true)}/>
                 <MoreMenuItem text="Move (m)" icon={<FiArrowRightCircle/>} onClick={() => setIsMove(true)}/>
+                <MoreMenuItem
+                    text={isPrivacyLoading ? "Loading..." : `Make ${snippet.privacy === "public" ? "private" : "public"}`}
+                    icon={snippet.privacy === "public" ? <FiLock/> : <FiGlobe/>}
+                    onClick={onTogglePrivacy}
+                    disabled={isPrivacyLoading}
+                />
                 <MoreMenuItem text="Delete" icon={<FiTrash/>} onClick={() => setIsDeleteOpen(true)}/>
             </MoreMenu>
             <UpModal isOpen={isDeleteOpen} setIsOpen={setIsDeleteOpen}>

--- a/components/SnippetLinkedPosts.tsx
+++ b/components/SnippetLinkedPosts.tsx
@@ -1,0 +1,14 @@
+import {DatedObj, IdObj, ProjectObjBasicWithOwner, SnippetObjGraph} from "../utils/types";
+import PostFeedItem from "./PostFeedItem";
+
+export default function SnippetLinkedPosts({snippet}: {snippet: DatedObj<SnippetObjGraph>}) {
+    return !!snippet.linkedPosts.length ? (
+        <div className="opacity-50 hover:opacity-100 transition pb-8">
+            <hr className="mb-8 mt-4"/>
+            <p className="up-ui-title mb-12">Linked posts ({snippet.linkedPosts.length}):</p>
+            {snippet.linkedPostsArr.map((d, i) => (
+                <PostFeedItem post={d} notFeed={true} i={i}/>
+            ))}
+        </div>
+    ) : <></>;
+}

--- a/components/SnippetLinkedPosts.tsx
+++ b/components/SnippetLinkedPosts.tsx
@@ -1,4 +1,4 @@
-import {DatedObj, IdObj, ProjectObjBasicWithOwner, SnippetObjGraph} from "../utils/types";
+import {DatedObj, SnippetObjGraph} from "../utils/types";
 import PostFeedItem from "./PostFeedItem";
 
 export default function SnippetLinkedPosts({snippet}: {snippet: DatedObj<SnippetObjGraph>}) {

--- a/components/SnippetModalReadArea.tsx
+++ b/components/SnippetModalReadArea.tsx
@@ -1,0 +1,53 @@
+import {DatedObj, SnippetObjGraph} from "../utils/types";
+import React, {Dispatch, ReactNode, SetStateAction} from "react";
+import SnippetItemLinkPreview from "./SnippetItemLinkPreview";
+import SlateReadOnly from "./SlateReadOnly";
+import SnippetLinkedPosts from "./SnippetLinkedPosts";
+import {useSession} from "next-auth/client";
+
+export default function SnippetModalReadArea({snippet, thisMoreMenu, isList, setTagsQuery}: {
+    snippet: DatedObj<SnippetObjGraph>,
+    thisMoreMenu?: ReactNode,
+    isList?: boolean,
+    setTagsQuery?: Dispatch<SetStateAction<string[]>>
+}) {
+    const [session, loading] = useSession();
+
+    return (
+        <>
+            <div className="flex">
+                <div className="w-full" style={{minWidth: 0}}>
+                    {snippet.url && (
+                        <SnippetItemLinkPreview snippet={snippet}/>
+                    )}
+                    <div className={`prose break-words`}>
+                        <SlateReadOnly nodes={snippet.slateBody}/>
+                    </div>
+                    {!!snippet.linkArr.length && (
+                        <>
+                            <hr className="mb-8 mt-4"/>
+                            <p className="up-ui-title">Linked resources ({snippet.linkArr.length}):</p>
+                            {snippet.linkArr.map(d => (
+                                <div className="my-2">
+                                    <SnippetItemLinkPreview url={d.targetUrl}/>
+                                </div>
+                            ))}
+                        </>
+                    )}
+                </div>
+                {session && session.userId === snippet.userId && thisMoreMenu}
+            </div>
+            {isList && (
+                <div className="flex mt-4">
+                    {snippet.tags && snippet.tags.map(tag => (
+                        <button
+                            className="font-bold opacity-50 mr-2"
+                            onClick={() => setTagsQuery && setTagsQuery([tag])}
+                        >#{tag}</button>
+                    ))}
+                </div>
+            )}
+            <SnippetLinkedPosts snippet={snippet}/>
+        </>
+    );
+}

--- a/components/SnippetModalShell.tsx
+++ b/components/SnippetModalShell.tsx
@@ -1,0 +1,72 @@
+import {DatedObj, SnippetObjGraph} from "../utils/types";
+import React, {Dispatch, ReactNode, SetStateAction} from "react";
+import {FiExternalLink, FiGlobe, FiLock} from "react-icons/fi";
+import Link from "next/link";
+import {format} from "date-fns";
+import UpInlineButton from "./style/UpInlineButton";
+import {useSession} from "next-auth/client";
+
+export default function SnippetModalShell({snippet, setTagsQuery, children}: {
+    snippet: DatedObj<SnippetObjGraph>,
+    setTagsQuery?: Dispatch<SetStateAction<string[]>>,
+    children: ReactNode,
+}) {
+    const [session, loading] = useSession();
+    const hasTags = snippet.tags && !!snippet.tags.length;
+
+    return (
+        <>
+            <div className="md:flex items-center px-2 py-4 bg-white">
+                <div className="mr-4" title={`Privacy: ${snippet.privacy}`}>
+                    {snippet.privacy === "private" ? (
+                        <FiLock className="up-gray-300"/>
+                    ) : (
+                        <Link href={`/@${snippet.authorArr[0].username}/s/${snippet._id}`}>
+                            <a>
+                                <FiGlobe/>
+                            </a>
+                        </Link>
+                    )}
+                </div>
+                <p className="up-gray-400">Posted on {format(new Date(snippet.createdAt), "MMMM d, yyyy 'at' h:mm a")}</p>
+                {hasTags && snippet.tags.map((tag, i) => (
+                    <button
+                        className={`up-gray-400 font-bold ${i === 0 ? "md:ml-auto" : "ml-2"}`}
+                        onClick={() => setTagsQuery && setTagsQuery([tag])}
+                    >
+                        #{tag}
+                    </button>
+                ))}
+                {session && (session.userId !== snippet.userId) && (
+                    <>
+                        <span className={`${hasTags ? "ml-6" : "ml-auto"} mr-2 up-gray-300`}>by</span>
+                        <UpInlineButton href={`/@${snippet.authorArr[0].username}`}>
+                            <div className="flex items-center">
+                                <img
+                                    src={snippet.authorArr[0].image}
+                                    alt={`Profile picture of ${snippet.authorArr[0].name}`}
+                                    className="w-6 h-6 rounded-full mr-2 opacity-75"
+                                />
+                                <span>{snippet.authorArr[0].name}</span>
+                            </div>
+                        </UpInlineButton>
+                    </>
+                )}
+                {snippet.privacy === "public" && (
+                    <UpInlineButton
+                        href={`/@${snippet.authorArr[0].username}/s/${snippet._id}`}
+                        className={"ml-auto"}
+                    >
+                        <div className="flex items-center">
+                            <span className="mr-2">Open as page</span>
+                            <FiExternalLink/>
+                        </div>
+                    </UpInlineButton>
+                )}
+            </div>
+            <div style={{maxHeight: "calc(100vh - 240px)", minHeight: 300, overflowY: "auto"}} className="-mx-4 px-6 pt-4 relative">
+                {children}
+            </div>
+        </>
+    );
+}

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -1,9 +1,9 @@
 import React, {Dispatch, ReactNode, SetStateAction} from "react";
 import {TabInfo} from "../utils/types";
 
-export default function Tabs({tabInfo, tab, setTab, className}: {tabInfo: TabInfo[], tab: string, setTab: Dispatch<SetStateAction<string>>, className?: string}) {
+export default function Tabs({tabInfo, tab, setTab, className, id}: {tabInfo: TabInfo[], tab: string, setTab: Dispatch<SetStateAction<string>>, className?: string, id?: string}) {
     return (
-        <div className={"flex items-center mb-8 " + (className || "")}>
+        <div className={"flex items-center mb-8 " + (className || "")} id={id || ""}>
             {tabInfo.map(thisTab => (
                 <button
                     className={`flex items-center mr-6 transition pb-2 border-b-2 ${tab === thisTab.name ? "font-bold up-border-gray-700" : "up-gray-400 hover:text-black border-transparent"}`}

--- a/components/navbar-quick-snippet-modal.tsx
+++ b/components/navbar-quick-snippet-modal.tsx
@@ -39,7 +39,7 @@ export default function NavbarQuickSnippetModal({setOpen, initProjectId, iterati
         return thisProject ? thisProject.availableTags : [];
     }
 
-    function onSubmit(urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], privacy: "public" | "private", isSlate: boolean) {
+    function onSubmit(urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], isSlate: boolean) {
         setIsLoading(true);
 
         axios.post("/api/snippet", {
@@ -50,7 +50,6 @@ export default function NavbarQuickSnippetModal({setOpen, initProjectId, iterati
             url: url || "",
             tags: tags || [],
             isSlate: isSlate,
-            privacy: privacy,
         }).then(() => {
             // @ts-ignore
             window.analytics.track("Item created", {

--- a/components/navbar-quick-snippet-modal.tsx
+++ b/components/navbar-quick-snippet-modal.tsx
@@ -39,7 +39,7 @@ export default function NavbarQuickSnippetModal({setOpen, initProjectId, iterati
         return thisProject ? thisProject.availableTags : [];
     }
 
-    function onSubmit(urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], isSlate: boolean) {
+    function onSubmit(urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], privacy: "public" | "private", isSlate: boolean) {
         setIsLoading(true);
 
         axios.post("/api/snippet", {
@@ -50,6 +50,7 @@ export default function NavbarQuickSnippetModal({setOpen, initProjectId, iterati
             url: url || "",
             tags: tags || [],
             isSlate: isSlate,
+            privacy: privacy,
         }).then(() => {
             // @ts-ignore
             window.analytics.track("Item created", {

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -123,9 +123,9 @@ export default function Navbar() {
                                                         if (!notification.comment.length && !notification.reaction.length) return "Notification outdated";
                                                         const type = notification.type;
                                                         const isComment = ["postComment", "postCommentReply"].includes(type);
-                                                        const author = isComment ? notification.comment[0].author[0] : notification.reaction[0].author[0];
+                                                        const author = isComment ? notification.comment[0].authorArr[0] : notification.reaction[0].authorArr[0];
                                                         const target = isComment ? notification.comment[0].post[0] : notification.reaction[0].post[0];
-                                                        const targetAuthor = target && target.author[0];
+                                                        const targetAuthor = target && target.authorArr[0];
 
                                                         if (!targetAuthor) {
                                                             return "Invalid notification";
@@ -144,7 +144,7 @@ export default function Navbar() {
                                                         const type = notification.type;
                                                         const isComment = ["postComment", "postCommentReply"].includes(type);
                                                         const target = isComment ? notification.comment[0].post[0] : notification.reaction[0].post[0];
-                                                        const targetAuthor = target && target.author[0];
+                                                        const targetAuthor = target && target.authorArr[0];
                                                         if (!targetAuthor) return "";
                                                         return `/@${targetAuthor.username}/p/${target.urlName}?notif=${notification._id}`;
                                                     })()}

--- a/components/snippet-editor.tsx
+++ b/components/snippet-editor.tsx
@@ -112,7 +112,7 @@ export default function SnippetEditor({isSnippet = false, snippet = null, projec
                     </UpInlineButton>
                 </>
             )}
-            <div className="content prose w-full relative" style={{minHeight: 200}}>
+            <div className="prose w-full relative" style={{minHeight: 200, fontSize: 18}}>
                 <SlateEditor
                     body={slateBody}
                     setBody={setSlateBody}

--- a/components/snippet-editor.tsx
+++ b/components/snippet-editor.tsx
@@ -20,7 +20,7 @@ export default function SnippetEditor({isSnippet = false, snippet = null, projec
     projectId?: string,
     availableTags: string[],
     isLoading: boolean,
-    onSaveEdit: (urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], privacy: "public" | "private", isSlate: boolean) => void,
+    onSaveEdit: (urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], isSlate: boolean) => void,
     onCancelEdit: (urlName: string) => void,
     setInstance?: Dispatch<SetStateAction<EasyMDE>>,
     disableSave?: boolean,
@@ -40,7 +40,7 @@ export default function SnippetEditor({isSnippet = false, snippet = null, projec
 
     const disableSaveFinal = disableSave || (isSnippetState && slateBody.every(d => getIsEmpty(d))) || (!isSnippetState && !url);
 
-    const onSaveEditFilled = () => onSaveEdit(urlName, isSnippetState, slateBody, url, tags, privacy, true);
+    const onSaveEditFilled = () => onSaveEdit(urlName, isSnippetState, slateBody, url, tags, true);
 
     useEffect(() => {
         window.onbeforeunload = !slateBody.every(d => getIsEmpty(d)) ? () => true : undefined;
@@ -127,27 +127,14 @@ export default function SnippetEditor({isSnippet = false, snippet = null, projec
                 </SlateEditor>
             </div>
             <hr className="my-6"/>
-            <div className="sm:grid grid-cols-2 gap-x-4">
-                <div>
-                    <p className="up-ui-title mb-4">Privacy</p>
-                    <Select
-                        options={[{label: "Public", value: "public"}, {label: "Private", value: "private"}]}
-                        value={{label: privacy.charAt(0).toUpperCase() + privacy.substr(1), value: privacy}}
-                        onChange={newValue => setPrivacy(newValue.value)}
-                    />
-                </div>
-                <hr className="sm:hidden"/>
-                <div>
-                    <p className="up-ui-title mb-4">Tags</p>
-                    <Creatable
-                        options={availableTags ? availableTags.map(d => ({label: d, value: d})) : []}
-                        value={tags ? tags.map(d => ({label: d, value: d})) : []}
-                        onChange={(newValue) => setTags(newValue.map(d => d.value))}
-                        isMulti
-                    />
-                    <p className="opacity-50 mt-4 text-xs text-right">Select an existing tag in this project or create a new one</p>
-                </div>
-            </div>
+            <p className="up-ui-title mb-4">Tags</p>
+            <Creatable
+                options={availableTags ? availableTags.map(d => ({label: d, value: d})) : []}
+                value={tags ? tags.map(d => ({label: d, value: d})) : []}
+                onChange={(newValue) => setTags(newValue.map(d => d.value))}
+                isMulti
+            />
+            <p className="opacity-50 mt-4 text-xs text-right">Select an existing tag in this project or create a new one</p>
             <hr className="my-6"/>
             <div className="flex">
                 <SpinnerButton

--- a/components/snippet-editor.tsx
+++ b/components/snippet-editor.tsx
@@ -1,6 +1,7 @@
 import React, {Dispatch, SetStateAction, useEffect, useState} from "react";
 import {DatedObj, SnippetObjGraph} from "../utils/types";
 import SpinnerButton from "./spinner-button";
+import Select from "react-select";
 import Creatable from "react-select/creatable";
 import {format} from "date-fns";
 import short from "short-uuid";
@@ -19,7 +20,7 @@ export default function SnippetEditor({isSnippet = false, snippet = null, projec
     projectId?: string,
     availableTags: string[],
     isLoading: boolean,
-    onSaveEdit: (urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], isSlate: boolean) => void,
+    onSaveEdit: (urlName: string, isSnippet: boolean, body: string | Node[], url: string, tags: string[], privacy: "public" | "private", isSlate: boolean) => void,
     onCancelEdit: (urlName: string) => void,
     setInstance?: Dispatch<SetStateAction<EasyMDE>>,
     disableSave?: boolean,
@@ -35,10 +36,11 @@ export default function SnippetEditor({isSnippet = false, snippet = null, projec
     const [tags, setTags] = useState<string[]>(snippet ? snippet.tags : []);
     const [urlName, setUrlName] = useState<string>(snippet ? snippet.urlName : format(new Date(), "yyyy-MM-dd-") + short.generate());
     const [isSnippetState, setIsSnippetState] = useState<boolean>(snippet ? snippet.type === "snippet" : isSnippet);
+    const [privacy, setPrivacy] = useState<"private" | "public">(snippet ? snippet.privacy : "private");
 
     const disableSaveFinal = disableSave || (isSnippetState && slateBody.every(d => getIsEmpty(d))) || (!isSnippetState && !url);
 
-    const onSaveEditFilled = () => onSaveEdit(urlName, isSnippetState, slateBody, url, tags, true);
+    const onSaveEditFilled = () => onSaveEdit(urlName, isSnippetState, slateBody, url, tags, privacy, true);
 
     useEffect(() => {
         window.onbeforeunload = !slateBody.every(d => getIsEmpty(d)) ? () => true : undefined;
@@ -125,14 +127,27 @@ export default function SnippetEditor({isSnippet = false, snippet = null, projec
                 </SlateEditor>
             </div>
             <hr className="my-6"/>
-            <p className="up-ui-title mb-4">Tags</p>
-            <Creatable
-                options={availableTags ? availableTags.map(d => ({label: d, value: d})) : []}
-                value={tags ? tags.map(d => ({label: d, value: d})) : []}
-                onChange={(newValue) => setTags(newValue.map(d => d.value))}
-                isMulti
-            />
-            <p className="opacity-50 mt-4 text-xs text-right">Select an existing tag in this project or type to create a new one</p>
+            <div className="sm:grid grid-cols-2 gap-x-4">
+                <div>
+                    <p className="up-ui-title mb-4">Privacy</p>
+                    <Select
+                        options={[{label: "Public", value: "public"}, {label: "Private", value: "private"}]}
+                        value={{label: privacy.charAt(0).toUpperCase() + privacy.substr(1), value: privacy}}
+                        onChange={newValue => setPrivacy(newValue.value)}
+                    />
+                </div>
+                <hr className="sm:hidden"/>
+                <div>
+                    <p className="up-ui-title mb-4">Tags</p>
+                    <Creatable
+                        options={availableTags ? availableTags.map(d => ({label: d, value: d})) : []}
+                        value={tags ? tags.map(d => ({label: d, value: d})) : []}
+                        onChange={(newValue) => setTags(newValue.map(d => d.value))}
+                        isMulti
+                    />
+                    <p className="opacity-50 mt-4 text-xs text-right">Select an existing tag in this project or create a new one</p>
+                </div>
+            </div>
             <hr className="my-6"/>
             <div className="flex">
                 <SpinnerButton

--- a/migrations/20210719211152-add-snippet-privacy.js
+++ b/migrations/20210719211152-add-snippet-privacy.js
@@ -1,5 +1,5 @@
 module.exports = {
   async up(db, client) {
-    await db.collection("snippets").update({_id: {$exists: true}}, {$set: {privacy: "private"}});
+    await db.collection("snippets").updateMany({_id: {$exists: true}}, {$set: {privacy: "private"}});
   }
 }

--- a/migrations/20210719211152-add-snippet-privacy.js
+++ b/migrations/20210719211152-add-snippet-privacy.js
@@ -1,0 +1,5 @@
+module.exports = {
+  async up(db, client) {
+    await db.collection("snippets").update({_id: {$exists: true}}, {$set: {privacy: "private"}});
+  }
+}

--- a/migrations/20210721070743-fix-snippet-and-post-previews.js
+++ b/migrations/20210721070743-fix-snippet-and-post-previews.js
@@ -1,0 +1,54 @@
+const jsdom = require("jsdom");
+const { JSDOM } = jsdom;
+
+function htmlDecode(input) {
+  const dom = new JSDOM(input);
+  return dom.window.document.body.textContent;
+}
+
+module.exports = {
+  async up(db, client) {
+    // get all snippets and posts
+    const allSnippets = await db.collection("snippets").find({slateBody: {$exists: true}}).toArray();
+    const allPosts = await db.collection("posts").find({slateBody: {$exists: true}}).toArray();
+
+    // make and execute link creation requests
+    let requests = [];
+
+    for (let snippet of allSnippets) {
+      requests.push({
+        updateOne: {
+          filter: {_id: snippet._id},
+          update: {$set: {body: htmlDecode(htmlDecode(htmlDecode(snippet.body)))}},
+        }
+      })
+      if (requests.length % 100 === 0) console.log("creating request " + requests.length);
+      if (requests.length === 500) {
+        console.log("making bulk requests");
+        await db.collection("snippets").bulkWrite(requests);
+        requests = [];
+      }
+    }
+
+    await db.collection("snippets").bulkWrite(requests);
+    requests = [];
+
+    for (let post of allPosts) {
+      requests.push({
+        updateOne: {
+          filter: {_id: post._id},
+          update: {$set: {body: htmlDecode(htmlDecode(htmlDecode(post.body)))}},
+        }
+      })
+      if (requests.length % 100 === 0) console.log("creating request " + requests.length);
+      if (requests.length === 500) {
+        console.log("making bulk requests");
+        await db.collection("posts").bulkWrite(requests);
+        requests = [];
+      }
+    }
+
+    await db.collection("posts").bulkWrite(requests);
+    requests = [];
+  },
+};

--- a/models/snippet.ts
+++ b/models/snippet.ts
@@ -12,6 +12,7 @@ const SnippetSchema = new mongoose.Schema({
     url: {type: String, required: false},
     tags: [{type: String, required: true}],
     linkedPosts: [mongoose.Schema.Types.ObjectId],
+    privacy: {type: String, required: true},
 }, {
     timestamps: true,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "updately-pro",
-  "version": "0.19.4",
+  "version": "0.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.19.4",
+      "version": "0.20.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.5.0",
         "@tailwindcss/typography": "^0.4.0",
@@ -25,6 +25,7 @@
         "frappe-charts": "^1.5.7",
         "html-react-parser": "^1.2.3",
         "is-hotkey": "^0.2.0",
+        "jsdom": "^16.6.0",
         "link-preview-js": "^2.1.6",
         "migrate-mongo": "^8.1.4",
         "mongoose": "^5.11.14",
@@ -1470,6 +1471,14 @@
         "tippy.js": "^6.3.1"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/bson": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
@@ -2267,6 +2276,11 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "node_modules/abab": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2282,6 +2296,26 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
       "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      }
+    },
+    "node_modules/acorn-globals/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2577,6 +2611,11 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "optional": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -2869,6 +2908,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "node_modules/browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -3544,6 +3588,17 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -4084,6 +4139,27 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+    },
     "node_modules/csstype": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
@@ -4109,6 +4185,51 @@
       "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "dependencies": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/date-fns": {
@@ -4143,6 +4264,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -4171,6 +4297,11 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "node_modules/define-property": {
       "version": "2.0.2",
@@ -4231,6 +4362,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/delegate": {
       "version": "3.2.0",
@@ -4380,6 +4519,25 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
       "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+    },
+    "node_modules/domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "dependencies": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/domhandler": {
       "version": "3.3.0",
@@ -4684,6 +4842,35 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -4986,6 +5173,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
     "node_modules/fast-shallow-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
@@ -5156,6 +5348,19 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -5628,6 +5833,17 @@
         "entities": "^2.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "dependencies": {
+        "whatwg-encoding": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
@@ -5675,6 +5891,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/https-browserify": {
@@ -6033,6 +6262,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -6108,6 +6342,99 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
+      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+      "dependencies": {
+        "abab": "^2.0.5",
+        "acorn": "^8.2.4",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.5.0",
+        "ws": "^7.4.5",
+        "xml-name-validator": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/acorn": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -6215,6 +6542,18 @@
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/line-column": {
@@ -6719,6 +7058,25 @@
       "version": "4.11.9",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
       "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+    },
+    "node_modules/mime-db": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "dependencies": {
+        "mime-db": "1.48.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/mimic-response": {
       "version": "2.1.0",
@@ -7457,6 +7815,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+    },
     "node_modules/oauth": {
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
@@ -7557,6 +7920,22 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/os-browserify": {
@@ -9056,6 +9435,14 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
@@ -9117,6 +9504,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "node_modules/psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -10011,6 +10403,17 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.20.2",
@@ -11113,6 +11516,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
     "node_modules/tailwindcss": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.0.2.tgz",
@@ -11589,6 +11997,27 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
@@ -11646,6 +12075,17 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "0.7.1",
@@ -12040,6 +12480,25 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
+    "node_modules/w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "dependencies": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "dependencies": {
+        "xml-name-validator": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -12409,6 +12868,19 @@
         "watchpack-chokidar2": "^2.0.1"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dependencies": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+    },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
@@ -12437,6 +12909,14 @@
       "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/worker-farm": {
@@ -12513,6 +12993,31 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "node_modules/ws": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
     "node_modules/xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -12532,6 +13037,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -13904,6 +14414,11 @@
         "tippy.js": "^6.3.1"
       }
     },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+    },
     "@types/bson": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
@@ -14705,6 +15220,11 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "abab": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -14717,6 +15237,22 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
       "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
+    },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        }
+      }
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -14969,6 +15505,11 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "optional": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -15213,6 +15754,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -15799,6 +16345,14 @@
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "optional": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -16283,6 +16837,26 @@
         }
       }
     },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+        }
+      }
+    },
     "csstype": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
@@ -16307,6 +16881,41 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
       "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+        },
+        "whatwg-url": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+          "requires": {
+            "lodash": "^4.7.0",
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
+      }
+    },
     "date-fns": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
@@ -16330,6 +16939,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -16349,6 +16963,11 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "optional": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "define-property": {
       "version": "2.0.2",
@@ -16396,6 +17015,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegate": {
       "version": "3.2.0",
@@ -16519,6 +17143,21 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
       "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+    },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+        }
+      }
     },
     "domhandler": {
       "version": "3.3.0",
@@ -16803,6 +17442,25 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+        }
+      }
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -17045,6 +17703,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
     "fast-shallow-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
@@ -17194,6 +17857,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fraction.js": {
       "version": "4.0.13",
@@ -17603,6 +18276,14 @@
         }
       }
     },
+    "html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "requires": {
+        "whatwg-encoding": "^1.0.5"
+      }
+    },
     "html-entities": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
@@ -17644,6 +18325,16 @@
         "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "https-browserify": {
@@ -17945,6 +18636,11 @@
         }
       }
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -18002,6 +18698,75 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      }
+    },
+    "jsdom": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
+      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+      "requires": {
+        "abab": "^2.0.5",
+        "acorn": "^8.2.4",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.5.0",
+        "ws": "^7.4.5",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+          "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA=="
+        },
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+        },
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+        },
+        "whatwg-url": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+          "requires": {
+            "lodash": "^4.7.0",
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
       }
     },
     "json-parse-better-errors": {
@@ -18093,6 +18858,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "line-column": {
       "version": "1.0.2",
@@ -18545,6 +19319,19 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         }
+      }
+    },
+    "mime-db": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
+    },
+    "mime-types": {
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "requires": {
+        "mime-db": "1.48.0"
       }
     },
     "mimic-response": {
@@ -19217,6 +20004,11 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "optional": true
     },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+    },
     "oauth": {
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
@@ -19296,6 +20088,19 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
       }
     },
     "os-browserify": {
@@ -20578,6 +21383,11 @@
         }
       }
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
     "pretty-format": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
@@ -20633,6 +21443,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -21460,6 +22275,14 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
     },
     "scheduler": {
       "version": "0.20.2",
@@ -22421,6 +23244,11 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
     "tailwindcss": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.0.2.tgz",
@@ -22801,6 +23629,23 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
+      }
+    },
     "tr46": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
@@ -22852,6 +23697,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-fest": {
       "version": "0.7.1",
@@ -23180,6 +24033,22 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      }
+    },
     "warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -23494,6 +24363,19 @@
         "source-map": "~0.6.1"
       }
     },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+    },
     "whatwg-url": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
@@ -23523,6 +24405,11 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "worker-farm": {
       "version": "1.7.0",
@@ -23585,6 +24472,17 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "ws": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "requires": {}
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
     "xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -23598,6 +24496,11 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "frappe-charts": "^1.5.7",
     "html-react-parser": "^1.2.3",
     "is-hotkey": "^0.2.0",
+    "jsdom": "^16.6.0",
     "link-preview-js": "^2.1.6",
     "migrate-mongo": "^8.1.4",
     "mongoose": "^5.11.14",

--- a/pages/[username]/[projectUrlName]/[postUrlName]/index.tsx
+++ b/pages/[username]/[projectUrlName]/[postUrlName]/index.tsx
@@ -81,11 +81,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
             if (!isOwner && !isCollaborator) return { notFound: true };
         }
 
-        context.res.setHeader("location", `/@${thisAuthor._id}/p/${encodeURIComponent(postUrlName)}`);
-        context.res.statusCode = 302;
-        context.res.end();
-
-        return { props: {} };
+        return {redirect: {permanent: false, destination: "`/@${thisAuthor._id}/p/${encodeURIComponent(postUrlName)}`"}};
     } catch (e) {
         console.log(e);
         return { notFound: true };

--- a/pages/[username]/[projectUrlName]/edit.tsx
+++ b/pages/[username]/[projectUrlName]/edit.tsx
@@ -127,10 +127,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
         // redirect if not authenticated or authorized
         if (!session || !session.userId || thisUser._id.toString() !== session.userId) {
-            context.res.setHeader("location", `/@${username}/${projectUrlName}`);
-            context.res.statusCode = 302;
-            context.res.end();
-            return {props: {}};
+            return {redirect: {permanent: false, destination: `/@${username}/${projectUrlName}`}};
         }
 
         const thisProject = await ProjectModel.findOne({ userId: thisUser._id, urlName: projectUrlName });

--- a/pages/[username]/[projectUrlName]/index.tsx
+++ b/pages/[username]/[projectUrlName]/index.tsx
@@ -33,6 +33,7 @@ import SnippetItemCard from "../../../components/SnippetItemCard";
 import PostItemCard from "../../../components/PostItemCard";
 import SnippetItemCardReadOnly from "../../../components/SnippetItemCardReadOnly";
 import Link from "next/link";
+import ProjectSnippetBrowser from "../../../components/ProjectSnippetBrowser";
 
 export default function ProjectPage({projectData, thisUser}: { projectData: DatedObj<ProjectObjWithPageStats>, thisUser: DatedObj<UserObjWithProjects>}) {
     const [session, loading] = useSession();
@@ -102,43 +103,13 @@ export default function ProjectPage({projectData, thisUser}: { projectData: Date
                 ) : (
                     <Skeleton count={1} className="h-32 w-full mt-12"/>
                 ), snippets: (
-                    <>
-                        <p className="mb-4 up-gray-400">
-                            {isOwner ? (
-                                <span>You are viewing this project's snippets as a public visitor. To see all your snippets, go to the <Link
-                                    href={`/projects/${projectData._id}`}
-                                ><a
-                                    className="underline"
-                                >project dashboard</a></Link>.</span>
-                            ) : (
-                                <span>Snippets are source notes that eventually turn into posts.</span>
-                            )}
-                        </p>
-                        {snippetsReady ? !!snippets.snippets.length ? (
-                            <div className="mb-12 -mt-8">
-                                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                                    {snippets.snippets.map((item, i, a) => (
-                                        <>
-                                            {(i === 0 || format(new Date(item.createdAt), "yyyy-MM-dd") !== format(new Date(a[i - 1].createdAt), "yyyy-MM-dd")) && (
-                                                <p className="up-ui-title mt-12 pb-4 md:col-span-2 xl:col-span-3">{format(new Date(item.createdAt), "EEEE, MMMM d")}</p>
-                                            )}
-                                            <SnippetItemCardReadOnly snippet={item}/>
-                                        </>
-                                    ))}
-                                </div>
-                                <PaginationBar
-                                    page={snippetPage}
-                                    count={snippets.count}
-                                    label="snippet"
-                                    setPage={setSnippetPage}
-                                />
-                            </div>
-                        ) : (
-                            <p>No public snippets have been published in this project yet.</p>
-                        ) : (
-                            <Skeleton count={1} className="h-32 w-full mt-12"/>
-                        )}
-                    </>
+                    <ProjectSnippetBrowser
+                        snippets={snippets}
+                        snippetPage={snippetPage}
+                        setSnippetPage={setSnippetPage}
+                        isOwner={isOwner}
+                        projectId={projectData._id}
+                    />
                 ), stats: (
                     <ActivityTabs
                         snippetsArr={projectData.snippetsArr}

--- a/pages/[username]/[projectUrlName]/index.tsx
+++ b/pages/[username]/[projectUrlName]/index.tsx
@@ -103,11 +103,17 @@ export default function ProjectPage({projectData, thisUser}: { projectData: Date
                     <Skeleton count={1} className="h-32 w-full mt-12"/>
                 ), snippets: (
                     <>
-                        {isOwner && (
-                            <p className="mb-4 up-gray-400">You are viewing this project's snippets as a public visitor. To see all your snippets, go to the <Link href={`/projects/${projectData._id}`}><a
-                                className="underline"
-                            >project dashboard</a></Link>.</p>
-                        )}
+                        <p className="mb-4 up-gray-400">
+                            {isOwner ? (
+                                <span>You are viewing this project's snippets as a public visitor. To see all your snippets, go to the <Link
+                                    href={`/projects/${projectData._id}`}
+                                ><a
+                                    className="underline"
+                                >project dashboard</a></Link>.</span>
+                            ) : (
+                                <span>Snippets are source notes that eventually turn into posts.</span>
+                            )}
+                        </p>
                         {snippetsReady ? !!snippets.snippets.length ? (
                             <div className="mb-12 -mt-8">
                                 <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">

--- a/pages/[username]/[projectUrlName]/index.tsx
+++ b/pages/[username]/[projectUrlName]/index.tsx
@@ -70,11 +70,11 @@ export default function ProjectPage({projectData, thisUser}: { projectData: Date
             <Tabs tabInfo={[
                 {
                     name: "posts",
-                    text: "Posts",
+                    text: `Posts (${postsReady ? posts.count : "loading..."})`,
                 },
                 {
                     name: "snippets",
-                    text: "Snippets",
+                    text: `Snippets (${snippetsReady ? snippets.count : "loading..."})`,
                 },
                 {
                     name: "stats",

--- a/pages/[username]/[projectUrlName]/index.tsx
+++ b/pages/[username]/[projectUrlName]/index.tsx
@@ -17,8 +17,11 @@ import UpInlineButton from "../../../components/style/UpInlineButton";
 import UpSEO from "../../../components/up-seo";
 import Tabs from "../../../components/Tabs";
 import ActivityTabs from "../../../components/ActivityTabs";
+import ProjectDashboardDropdown from "../../../components/ProjectDashboardDropdown";
+import {useSession} from "next-auth/client";
 
 export default function ProjectPage({projectData, thisUser}: { projectData: DatedObj<ProjectObjWithPageStats>, thisUser: DatedObj<UserObjWithProjects>}) {
+    const [session, loading] = useSession();
     const [postPage, setPostPage] = useState<number>(1);
     const [searchQuery, setSearchQuery] = useState<string>("");
     const [tab, setTab] = useState<"posts" | "snippets" | "stats">("posts");
@@ -27,15 +30,11 @@ export default function ProjectPage({projectData, thisUser}: { projectData: Date
 
     const postsReady = posts && posts.posts;
 
+    const isOwner = session && session.userId === projectData.userId;
+
     return (
         <ProfileShell thisUser={thisUser} selectedProjectId={projectData._id}>
             <UpSEO title={projectData.name}/>
-            {/*<UpInlineButton href={`/@${thisUser.username}`} className="inline-flex items-center mb-8">*/}
-            {/*    <FiArrowLeft/>*/}
-            {/*    <span className="ml-2">*/}
-            {/*        Back to profile*/}
-            {/*    </span>*/}
-            {/*</UpInlineButton>*/}
             <div className="items-center mb-8 hidden lg:flex">
                 <UpInlineButton href={`/@${thisUser.username}`} light={true}>
                     {thisUser.name}
@@ -43,7 +42,10 @@ export default function ProjectPage({projectData, thisUser}: { projectData: Date
                 <span className="mx-2 up-gray-300">/</span>
             </div>
             <div className="mb-12">
-                <H1>{projectData.name}</H1>
+                <div className="flex items-center">
+                    <H1>{projectData.name}</H1>
+                    {isOwner && <ProjectDashboardDropdown projectId={projectData._id} className="ml-2"/>}
+                </div>
                 {projectData.description && (
                     <H2 className="mt-2">{projectData.description}</H2>
                 )}

--- a/pages/[username]/index.tsx
+++ b/pages/[username]/index.tsx
@@ -83,7 +83,7 @@ export default function UserProfile({thisUser}: { thisUser: DatedObj<UserObjGrap
                 {isOwner && (
                     <>
                         <button
-                            className="flex items-center justify-center up-gray-300 rounded-md hover:up-gray-700 hover:shadow transition"
+                            className="flex items-center justify-center up-gray-300 rounded-md up-bg-gray-50 hover:bg-white hover:up-gray-700 hover:shadow transition"
                             style={{minHeight: 160}}
                             onClick={() => setAddFeaturedOpen(true)}
                         >
@@ -102,12 +102,15 @@ export default function UserProfile({thisUser}: { thisUser: DatedObj<UserObjGrap
                         </UpModal>
                     </>
                 )}
-            </div>
-            <div className="flex justify-end my-8">
-                <UpInlineButton href={`/@${thisUser.username}/projects`} className="flex items-center" light={true}>
-                    <span className="mr-2">All projects ({thisUser.projectsArr.length})</span>
-                    <FiArrowRight/>
-                </UpInlineButton>
+                <Link href={`/@${thisUser.username}/projects`}>
+                    <a
+                        className="flex items-center justify-center font-medium up-gray-500 hover:up-gray-700 up-bg-gray-50 rounded-md hover:bg-white hover:shadow"
+                        style={{minHeight: 160, transition: "all 0.3s ease"}}
+                    >
+                        <span className="mr-2">All projects ({thisUser.projectsArr.length})</span>
+                        <FiArrowRight/>
+                    </a>
+                </Link>
             </div>
             <hr className="my-12"/>
             <H4 className="mb-8">Activity</H4>

--- a/pages/[username]/index.tsx
+++ b/pages/[username]/index.tsx
@@ -127,7 +127,9 @@ export default function UserProfile({thisUser}: { thisUser: DatedObj<UserObjGrap
             {tab === "posts" && (
                 <>
                     <Masonry className="mt-12 md:-mx-8 w-full" options={{transitionDuration: 0}}>
-                        {posts && posts.posts && posts.posts.map((post, i) => <PostFeedItem post={post} key={post._id} i={i}/>)}
+                        {posts && posts.posts && posts.posts.map((post, i) => (
+                            <PostFeedItem post={post} key={post._id} i={i}/>
+                        ))}
                     </Masonry>
                     <PaginationBar
                         page={page}

--- a/pages/[username]/p/[postUrlName].tsx
+++ b/pages/[username]/p/[postUrlName].tsx
@@ -41,6 +41,7 @@ import SnippetItemCard from "../../../components/SnippetItemCard";
 import SnippetItemCardReadOnly from "../../../components/SnippetItemCardReadOnly";
 import Link from "next/link";
 import ProjectDashboardDropdown from "../../../components/ProjectDashboardDropdown";
+import {snippetsExplainer} from "../../../utils/copy";
 
 export default function PostPage({postData, linkedSnippets, projectData, thisOwner, thisAuthor, thisLinks}: {
     postData: DatedObj<PostObj>,
@@ -259,7 +260,7 @@ export default function PostPage({postData, linkedSnippets, projectData, thisOwn
                 {tab === "snippets" && (
                     <>
                         {!isOwner && (
-                            <p className="up-gray-400 mb-8 -mt-4">Snippets are source notes that eventually turn into posts.</p>
+                            <p className="up-gray-400 mb-8 -mt-4">{snippetsExplainer}</p>
                         )}
                         <div className="grid grid-cols-2 gap-4 mb-12">
                             {linkedSnippets.length ? linkedSnippetsReady ? (

--- a/pages/[username]/p/[postUrlName].tsx
+++ b/pages/[username]/p/[postUrlName].tsx
@@ -247,19 +247,24 @@ export default function PostPage({postData, linkedSnippets, projectData, thisOwn
                     </>
                 )}
                 {tab === "snippets" && (
-                    <div className="grid grid-cols-2 gap-4 mb-12">
-                        {linkedSnippets.length ? linkedSnippetsReady ? (
-                            <>
-                                {linkedSnippetsData.snippets.map(snippet => (
-                                    <SnippetItemCardReadOnly snippet={snippet} showFullDate={true}/>
-                                ))}
-                            </>
-                        ) : (
-                            <p>Loading...</p>
-                        ) : (
-                            <p>This post doesn't have any snippets linked to it.</p>
+                    <>
+                        {!isOwner && (
+                            <p className="up-gray-400 mb-8 -mt-4">Snippets are source notes that eventually turn into posts.</p>
                         )}
-                    </div>
+                        <div className="grid grid-cols-2 gap-4 mb-12">
+                            {linkedSnippets.length ? linkedSnippetsReady ? (
+                                <>
+                                    {linkedSnippetsData.snippets.map(snippet => (
+                                        <SnippetItemCardReadOnly snippet={snippet} showFullDate={true}/>
+                                    ))}
+                                </>
+                            ) : (
+                                <p>Loading...</p>
+                            ) : (
+                                <p>This post doesn't have any snippets linked to it.</p>
+                            )}
+                        </div>
+                    </>
                 )}
             </div>
         </ProfileShell>

--- a/pages/[username]/p/[postUrlName].tsx
+++ b/pages/[username]/p/[postUrlName].tsx
@@ -152,7 +152,7 @@ export default function PostPage({postData, linkedSnippets, projectData, thisOwn
                     </div>
                 </div>
                 <div className="flex items-center mt-4 border-b pb-8">
-                    <p className="up-gray-400">{format(new Date(postData.createdAt), "MMMM d, yyyy")} | {readingTime(postData.body).text}{!isOwner && !!linkedSnippets.length && ` | ${linkedSnippets.length} linked snippets`}</p>
+                    <p className="up-gray-400">{format(new Date(postData.createdAt), "MMMM d, yyyy")} | {readingTime(postData.body).text}{!isOwner && !!linkedSnippets.length && ` | ${linkedSnippets.length} linked snippet${linkedSnippets.length === 1 ? "" : "s"}`}</p>
                     {reactions && reactions.data && (
                         <div className="ml-auto flex items-center">
                             {reactions.data.length > 0 && (

--- a/pages/[username]/p/[postUrlName].tsx
+++ b/pages/[username]/p/[postUrlName].tsx
@@ -112,6 +112,16 @@ export default function PostPage({postData, linkedSnippets, projectData, thisOwn
         }
     }, [router.query]);
 
+    useEffect(() => {
+        const routerPath = router.asPath;
+        const routerPathHasHash = routerPath.includes("#");
+        if (routerPathHasHash) {
+            const routerPathSplit = routerPath.split("#");
+            const routerHashValue = routerPathSplit[1];
+            if (routerHashValue === "snippets") setTab("snippets");
+        }
+    }, []);
+
     return (
         <ProfileShell thisUser={thisOwner} selectedProjectId={projectId}>
             <UpSEO

--- a/pages/[username]/p/[postUrlName].tsx
+++ b/pages/[username]/p/[postUrlName].tsx
@@ -29,7 +29,7 @@ import axios from "axios";
 import MoreMenu from "../../../components/more-menu";
 import MoreMenuItem from "../../../components/more-menu-item";
 import SpinnerButton from "../../../components/spinner-button";
-import {FiChevronDown, FiChevronUp, FiEdit2, FiTrash} from "react-icons/fi";
+import {FiChevronDown, FiChevronUp, FiEdit2, FiTrash, FiUser} from "react-icons/fi";
 import UpModal from "../../../components/up-modal";
 import {useRouter} from "next/router";
 import UpBanner from "../../../components/UpBanner";
@@ -40,6 +40,7 @@ import Tabs from "../../../components/Tabs";
 import SnippetItemCard from "../../../components/SnippetItemCard";
 import SnippetItemCardReadOnly from "../../../components/SnippetItemCardReadOnly";
 import Link from "next/link";
+import ProjectDashboardDropdown from "../../../components/ProjectDashboardDropdown";
 
 export default function PostPage({postData, linkedSnippets, projectData, thisOwner, thisAuthor, thisLinks}: {
     postData: DatedObj<PostObj>,
@@ -127,11 +128,14 @@ export default function PostPage({postData, linkedSnippets, projectData, thisOwn
                     <UpInlineButton href={`/@${thisOwner.username}`} light={true}>
                         {thisOwner.name}
                     </UpInlineButton>
-                    <span className="mx-2 up-gray-300">/</span>
-                    <UpInlineButton href={`/@${thisOwner.username}/${projectUrlName}`} light={true}>
-                        {projectName}
-                    </UpInlineButton>
-                    <span className="mx-2 up-gray-300"> / </span>
+                    <span className="mx-3 up-gray-300">/</span>
+                    <div className="flex items-center">
+                        <UpInlineButton href={`/@${thisOwner.username}/${projectUrlName}`} light={true}>
+                            {projectName}
+                        </UpInlineButton>
+                        {isOwner && <ProjectDashboardDropdown projectId={projectId}/>}
+                    </div>
+                    <span className="mx-3 up-gray-300"> / </span>
                 </div>
                 <div className="flex">
                     <h1 className="text-4xl font-medium up-font-display">{postData.title}</h1>

--- a/pages/[username]/projects.tsx
+++ b/pages/[username]/projects.tsx
@@ -11,7 +11,7 @@ import ProfileProjectItem from "../../components/ProfileProjectItem";
 
 export default function Projects({thisUser}: { thisUser: DatedObj<UserObjWithProjects> }) {
     return (
-        <ProfileShell thisUser={thisUser} featured={true}>
+        <ProfileShell thisUser={thisUser} isAllProjects={true}>
             <div className="flex items-center mb-8">
                 <UpInlineButton href={`/@${thisUser.username}`} light={true}>
                     {thisUser.name}

--- a/pages/[username]/s/[snippetId].tsx
+++ b/pages/[username]/s/[snippetId].tsx
@@ -52,7 +52,7 @@ export default function PostPage({snippet, thisAuthor, thisOwner, projectData}: 
                     </UpInlineButton>
                     <span className="mx-3 up-gray-300">/</span>
                     <div className="flex items-center">
-                        <UpInlineButton href={`/@${thisOwner.username}/${projectUrlName}`} light={true}>
+                        <UpInlineButton href={`/@${thisOwner.username}/${projectUrlName}#snippets`} light={true}>
                             {projectName}
                         </UpInlineButton>
                         {isOwner && <ProjectDashboardDropdown projectId={projectId}/>}

--- a/pages/[username]/s/[snippetId].tsx
+++ b/pages/[username]/s/[snippetId].tsx
@@ -36,7 +36,7 @@ export default function PostPage({snippet, thisAuthor, thisOwner, projectData}: 
     const {_id: projectId, userId, name: projectName, description, urlName: projectUrlName} = projectData;
 
     return (
-        <ProfileShell thisUser={thisOwner} selectedProjectId={projectId}>
+        <ProfileShell thisUser={thisOwner} selectedProjectId={projectId} isSnippet={true}>
             <UpSEO
                 title={`${format(new Date(snippet.createdAt), "MMMM d, yyyy")} snippet by ${thisAuthor.name}`}
                 description={snippet.body.substr(0, 200)}

--- a/pages/[username]/s/[snippetId].tsx
+++ b/pages/[username]/s/[snippetId].tsx
@@ -23,6 +23,7 @@ import {snippetsExplainer} from "../../../utils/copy";
 import Link from "next/link";
 import PostFeedItem from "../../../components/PostFeedItem";
 import {FiArrowLeft} from "react-icons/fi";
+import SnippetLinkedPosts from "../../../components/SnippetLinkedPosts";
 
 export default function PostPage({snippet, thisAuthor, thisOwner, projectData}: {
     snippet: DatedObj<SnippetObjGraph>,
@@ -87,15 +88,7 @@ export default function PostPage({snippet, thisAuthor, thisOwner, projectData}: 
                                 isOwner={false}
                             />
                         </div>
-                        {!!snippet.linkedPosts.length && (
-                            <div className="opacity-50 hover:opacity-100 transition pb-8">
-                                <hr className="mb-8 mt-4"/>
-                                <p className="up-ui-title mb-12">Linked posts ({snippet.linkedPosts.length}):</p>
-                                {snippet.linkedPostsArr.map((d, i) => (
-                                    <PostFeedItem post={{...d, projectArr: [projectData]}} notFeed={true} i={i}/>
-                                ))}
-                            </div>
-                        )}
+                        <SnippetLinkedPosts snippet={snippet}/>
                     </div>
                 </div>
                 <UpInlineButton className="my-8" href={`/@${thisOwner.username}/${projectUrlName}#snippets`}>

--- a/pages/[username]/s/[snippetId].tsx
+++ b/pages/[username]/s/[snippetId].tsx
@@ -1,0 +1,160 @@
+import {GetServerSideProps} from "next";
+import dbConnect from "../../../utils/dbConnect";
+import {UserModel} from "../../../models/user";
+import {cleanForJSON, findImages, snippetGraphStages} from "../../../utils/utils";
+import * as mongoose from "mongoose";
+import {
+    DatedObj,
+    ProjectObjWithOwnerWithProjects,
+    SnippetObjGraph,
+    UserObj,
+    UserObjWithProjects
+} from "../../../utils/types";
+import ProfileShell from "../../../components/ProfileShell";
+import UpSEO from "../../../components/up-seo";
+import React from "react";
+import {format} from "date-fns";
+import UpInlineButton from "../../../components/style/UpInlineButton";
+import ProjectDashboardDropdown from "../../../components/ProjectDashboardDropdown";
+import {useSession} from "next-auth/client";
+import SlateReadOnly from "../../../components/SlateReadOnly";
+import H1 from "../../../components/style/H1";
+import {snippetsExplainer} from "../../../utils/copy";
+import Link from "next/link";
+import PostFeedItem from "../../../components/PostFeedItem";
+import {FiArrowLeft} from "react-icons/fi";
+
+export default function PostPage({snippet, thisAuthor, thisOwner, projectData}: {
+    snippet: DatedObj<SnippetObjGraph>,
+    projectData: DatedObj<ProjectObjWithOwnerWithProjects>,
+    thisAuthor: DatedObj<UserObj>,
+    thisOwner: DatedObj<UserObjWithProjects>,
+}) {
+    const [session, loading] = useSession();
+    const isOwner = session && (session.userId === thisAuthor._id);
+    const {_id: projectId, userId, name: projectName, description, urlName: projectUrlName} = projectData;
+
+    return (
+        <ProfileShell thisUser={thisOwner} selectedProjectId={projectId}>
+            <UpSEO
+                title={`${format(new Date(snippet.createdAt), "MMMM d, yyyy")} snippet by ${thisAuthor.name}`}
+                description={snippet.body.substr(0, 200)}
+                projectName={projectData.name}
+                imgUrl={findImages(snippet.slateBody).length ?  findImages(snippet.slateBody)[0] : null}
+                authorUsername={thisAuthor.username}
+                publishedDate={snippet.createdAt}
+                noindex={snippet.privacy !== "public"}
+            />
+            <div className="max-w-3xl">
+                <div className="items-center mb-8 hidden lg:flex">
+                    <UpInlineButton href={`/@${thisOwner.username}`} light={true}>
+                        {thisOwner.name}
+                    </UpInlineButton>
+                    <span className="mx-3 up-gray-300">/</span>
+                    <div className="flex items-center">
+                        <UpInlineButton href={`/@${thisOwner.username}/${projectUrlName}`} light={true}>
+                            {projectName}
+                        </UpInlineButton>
+                        {isOwner && <ProjectDashboardDropdown projectId={projectId}/>}
+                    </div>
+                    <span className="mx-3 up-gray-300"> / </span>
+                    <span className="up-gray-300">Snippet</span>
+                </div>
+                {!isOwner && (
+                    <p className="up-gray-400 mb-8">{snippetsExplainer}</p>
+                )}
+                <div className="rounded-md p-4 border my-8">
+                    <div style={{maxWidth: "65ch"}} className="mx-auto">
+                        <div className="mt-8 mb-4 flex items-center">
+                            <UpInlineButton href={`/@${thisAuthor.username}`}>
+                                <div className="flex items-center">
+                                    <img
+                                        src={thisAuthor.image}
+                                        alt={`Profile picture of ${thisAuthor.name}`}
+                                        className="w-6 h-6 rounded-full mr-2 opacity-75"
+                                    />
+                                    <span>{snippet.authorArr[0].name}</span>
+                                </div>
+                            </UpInlineButton>
+                            <p className="up-gray-400 ml-auto">{format(new Date(snippet.createdAt), "MMMM d, yyyy 'at' h:mm a")}</p>
+                        </div>
+                        <div className="prose mb-8">
+                            <SlateReadOnly
+                                nodes={snippet.slateBody}
+                                projectId={projectData._id}
+                                projectName={projectData.name}
+                                ownerName={thisOwner.name}
+                                isOwner={false}
+                            />
+                        </div>
+                        {!!snippet.linkedPosts.length && (
+                            <div className="opacity-50 hover:opacity-100 transition pb-8">
+                                <hr className="mb-8 mt-4"/>
+                                <p className="up-ui-title mb-12">Linked posts ({snippet.linkedPosts.length}):</p>
+                                {snippet.linkedPostsArr.map((d, i) => (
+                                    <PostFeedItem post={{...d, projectArr: [projectData]}} notFeed={true} i={i}/>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </div>
+                <UpInlineButton className="my-8" href={`/@${thisOwner.username}/${projectUrlName}#snippets`}>
+                    <div className="flex items-center">
+                        <FiArrowLeft/>
+                        <span className="ml-2">Back to project</span>
+                    </div>
+                </UpInlineButton>
+            </div>
+        </ProfileShell>
+    )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    // 404 if not correct url format
+    if (
+        Array.isArray(context.params.username) ||
+        Array.isArray(context.params.snippetId) ||
+        context.params.username.substr(0, 1) !== "@"
+    ) {
+        return {notFound: true};
+    }
+
+    // parse URL params
+    const username: string = context.params.username.substr(1);
+    const snippetId: string = context.params.snippetId;
+
+    // fetch project info from MongoDB
+    try {
+        await dbConnect();
+
+        const graphObj = await UserModel.aggregate([
+            {$match: { "username": username }},
+            {
+                $lookup: {
+                    from: "snippets",
+                    let: {"userId": "$_id"},
+                    pipeline: [
+                        {$match: {$expr: {$and: [{$eq: ["$userId", "$$userId"]}, {$eq: ["$_id", mongoose.Types.ObjectId(snippetId)]}]}}},
+                        ...snippetGraphStages,
+                    ],
+                    as: "snippetArr",
+                }
+            },
+        ]);
+
+        // return 404 if missing object at any stage
+        if (!graphObj.length || !graphObj[0].snippetArr.length || !graphObj[0].snippetArr[0].projectArr.length || !graphObj[0].snippetArr[0].projectArr[0].ownerArr.length) {
+            return { notFound: true };
+        }
+
+        const thisAuthor = graphObj[0];
+        const thisSnippet: SnippetObjGraph = thisAuthor.snippetArr[0];
+        const thisProject = thisSnippet.projectArr[0];
+        const thisOwner = thisProject.ownerArr[0];
+
+        return { props: { snippet: cleanForJSON(thisSnippet), thisAuthor: cleanForJSON(thisAuthor), projectData: cleanForJSON(thisProject), thisOwner: cleanForJSON(thisOwner), key: snippetId }};
+    } catch (e) {
+        console.log(e);
+        return { notFound: true };
+    }
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,13 +10,13 @@ import "../styles/nprogress.css";
 import {createContext, useState} from "react";
 import {ToastProvider} from "react-toast-notifications";
 
-Router.events.on("routeChangeStart", (url) => {
-    NProgress.start();
+Router.events.on("routeChangeStart", (url, {shallow}) => {
+    if (!shallow) NProgress.start();
 });
-Router.events.on("routeChangeComplete", (url) => {
+Router.events.on("routeChangeComplete", (url, {shallow}) => {
     // @ts-ignore window.analytics undefined below
     window.analytics.page(url);
-    NProgress.done();
+    if (!shallow) NProgress.done();
 });
 Router.events.on("routeChangeError", () => NProgress.done());
 

--- a/pages/api/notification.ts
+++ b/pages/api/notification.ts
@@ -29,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                             from: "users",
                             localField: "userId",
                             foreignField: "_id",
-                            as: "author",
+                            as: "authorArr",
                         }}
                     ],
                     as: "post",
@@ -38,7 +38,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     from: "users",
                     localField: "userId",
                     foreignField: "_id",
-                    as: "author",
+                    as: "authorArr",
                 }},
             ];
 

--- a/pages/api/post/index.ts
+++ b/pages/api/post/index.ts
@@ -20,6 +20,7 @@ import {AES} from "crypto-js";
 import axios from "axios";
 import ellipsize from "ellipsize";
 import {EmailModel} from "../../../models/email";
+import htmlDecode from "../../../utils/htmlDecode";
 
 async function sendEmails(thisProject: DatedObj<ProjectObj>, session: any, thisPost: DatedObj<PostObj> | PostObj, postId?: string) {
     const recipients = await SubscriptionModel.find({targetId: thisPost.projectId});
@@ -84,10 +85,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 if (!req.body.body) return res.status(406).json({message: "No post body found in request."});
                 if (!["public", "private", "unlisted", "draft"].includes(req.body.privacy)) return res.status(406).json({message: "Missing or invalid privacy setting"});
 
-                const body = req.body.isSlate ? serialize({
+                const body = req.body.isSlate ? htmlDecode(htmlDecode(htmlDecode(serialize({
                     type: "div",
                     children: req.body.body,
-                }) : req.body.body;
+                })))) : req.body.body;
 
                 try {
                     await dbConnect();

--- a/pages/api/snippet.ts
+++ b/pages/api/snippet.ts
@@ -135,6 +135,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                         tags: req.body.tags,
                         userId: session.userId,
                         linkedPosts: [],
+                        privacy: req.body.privacy || "private",
                     }
 
                     const createdSnippet = await SnippetModel.create(newSnippet);

--- a/pages/api/snippet.ts
+++ b/pages/api/snippet.ts
@@ -11,6 +11,7 @@ import {serialize} from "remark-slate";
 import * as mongoose from "mongoose";
 import {checkProjectPermission, findImages, findLinks, getCursorStages, snippetGraphStages} from "../../utils/utils";
 import {LinkModel} from "../../models/link";
+import htmlDecode from "../../utils/htmlDecode";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (["POST", "DELETE"].includes(req.method)) {
@@ -79,10 +80,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 if (req.body.type === "snippet" && (!req.body.body || (req.body.isSlate && getIsEmpty(req.body.body)))) return res.status(406).json({message: "No snippet body found in request."});
                 if (req.body.type === "resource" && !req.body.url) return res.status(406).json({message: "No resource URL found in request."});
 
-                const body = req.body.isSlate ? serialize({
+                const body = req.body.isSlate ? htmlDecode(htmlDecode(htmlDecode(serialize({
                     type: "div",
                     children: req.body.body,
-                }) : req.body.body;
+                })))) : req.body.body;
 
                 let linksToAdd = findLinks(req.body.body);
 

--- a/pages/api/snippet.ts
+++ b/pages/api/snippet.ts
@@ -183,8 +183,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             return res.status(500).json({message: e});
         }
     } else if (req.method === "GET") {
-        if (!req.query.projectId && !req.query.ids) return res.status(406).json({message: "No project ID or snippet IDs found in request"});
-        if (Array.isArray(req.query.search) || Array.isArray(req.query.tags) || Array.isArray(req.query.userIds) || Array.isArray(req.query.ids) || Array.isArray(req.query.projectId) || Array.isArray(req.query.page)) return res.status(406).json({message: "Invalid filtering queries found in request"});
+        if (!req.query.projectId && !req.query.ids && !req.query.userId) return res.status(400).json({message: "Missing params"});
+        if (Array.isArray(req.query.search) || Array.isArray(req.query.tags) || Array.isArray(req.query.userIds) || Array.isArray(req.query.ids) || Array.isArray(req.query.projectId) || Array.isArray(req.query.page) || Array.isArray(req.query.userId)) return res.status(400).json({message: "Invalid filtering queries found in request"});
 
         const session = await getSession({ req });
 
@@ -210,7 +210,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 const ids: any = JSON.parse(req.query.ids).map(d => mongoose.Types.ObjectId(d));
                 conditions = { "_id": {"$in": ids}};
             }
-
+            if (req.query.userId) conditions = {"userId": mongoose.Types.ObjectId(req.query.userId), "privacy": "public"};
             if (req.query.projectId && (publicAccess || req.query.public)) conditions["privacy"] = "public";
 
             const cursorStages = getCursorStages(req.query.page);

--- a/pages/api/snippet.ts
+++ b/pages/api/snippet.ts
@@ -219,10 +219,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             if (!session || (snippets.length && session.userId !== snippets[0].userId.toString())) {
                 snippets = snippets.map(d => (d.privacy === "public") ? d : (() => {
                     let retval = {...d};
-                    delete retval.body;
-                    delete retval.slateBody;
-                    delete retval.tags;
-                    delete retval.linkedPosts;
+                    retval.body = retval.slateBody = retval.tags = retval.linkedPosts = null;
                     return retval;
                 })());
             }

--- a/pages/api/snippet.ts
+++ b/pages/api/snippet.ts
@@ -51,7 +51,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             if (req.body.id) {
                 thisSnippet = await SnippetModel.findOne({ _id: req.body.id });
 
-                if (!thisSnippet) return res.status(406).json({message: "No snippet found with given ID."});
+                if (!thisSnippet) return res.status(404).json({message: "No snippet found with given ID."});
 
                 thisProject = await ProjectModel.findOne({ _id: thisSnippet.projectId });
 
@@ -65,12 +65,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             // if update or create, else delete
             if (req.method === "POST") {
                 // moving snippet to a different project, else updating or creating
-                if (req.body.id && req.body.projectId) {
-                    thisSnippet.projectId = req.body.projectId;
+                if (req.body.id && (req.body.projectId || req.body.privacy)) {
+                    if (req.body.projectId) thisSnippet.projectId = req.body.projectId;
+                    if (req.body.privacy) thisSnippet.privacy = req.body.privacy;
 
                     await thisSnippet.save();
 
-                    return res.status(200).json({message: "Snippet successfully moved."});
+                    return res.status(200).json({message: "Snippet successfully updated."});
                 }
 
                 // ensure necessary post params are present
@@ -120,7 +121,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     if (req.body.isSlate) thisSnippet.slateBody = req.body.body;
                     thisSnippet.url = req.body.url || "";
                     thisSnippet.tags = req.body.tags || [];
-                    thisSnippet.privacy = req.body.privacy || "private";
 
                     await thisSnippet.save();
                 } else {
@@ -136,7 +136,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                         tags: req.body.tags,
                         userId: session.userId,
                         linkedPosts: [],
-                        privacy: req.body.privacy || "private",
+                        privacy: "private",
                     }
 
                     const createdSnippet = await SnippetModel.create(newSnippet);

--- a/pages/api/snippet.ts
+++ b/pages/api/snippet.ts
@@ -120,6 +120,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     if (req.body.isSlate) thisSnippet.slateBody = req.body.body;
                     thisSnippet.url = req.body.url || "";
                     thisSnippet.tags = req.body.tags || [];
+                    thisSnippet.privacy = req.body.privacy || "private";
 
                     await thisSnippet.save();
                 } else {

--- a/pages/auth/newaccount.tsx
+++ b/pages/auth/newaccount.tsx
@@ -93,11 +93,7 @@ export default function NewAccount() {
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const session = await getSession(context);
 
-    if (!session || session.userId) {
-        context.res.setHeader("location", session ? "/projects" : "/auth/signin");
-        context.res.statusCode = 302;
-        context.res.end();
-    }
+    if (!session || session.userId) return {redirect: {permanent: false, destination: session ? "/projects" : "/auth/signin"}};
 
     return {props: {}};
 };

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -40,11 +40,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
     if (session && !session.userId) return {props: {notAllowed: true}};
 
-    if (session && session.userId) {
-        context.res.setHeader("location", "/projects");
-        context.res.statusCode = 302;
-        context.res.end();
-    }
+    if (session && session.userId) return {redirect: {permanent: false, destination: "/projects"}};
 
     return {props: {notAllowed: false}};
 };

--- a/pages/auth/welcome.tsx
+++ b/pages/auth/welcome.tsx
@@ -19,11 +19,7 @@ export default function Welcome() {
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const session = await getSession(context);
 
-    if (session) {
-        context.res.setHeader("location", session.userId ? "/projects" : "/auth/newaccount");
-        context.res.statusCode = 302;
-        context.res.end();
-    }
+    if (session) return {redirect: {permanent: false, destination: session.userId ? "/projects" : "/auth/newaccount"}};
 
     return {props: {}};
 };

--- a/pages/post/[postId].tsx
+++ b/pages/post/[postId].tsx
@@ -173,13 +173,7 @@ export default function NewPost(props: {post: DatedObj<PostObj>, projectId: stri
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const session = await getSession(context);
 
-    if (!session) {
-        context.res.setHeader("location", session ? "/projects" : "/auth/signin");
-        context.res.statusCode = 302;
-        context.res.end();
-
-        return {props: {}};
-    }
+    if (!session) return {redirect: {permanent: false, destination: session ? "/projects" : "/auth/signin"}};
 
     if (Array.isArray(context.params.postId)) return {notFound: true};
 

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -71,11 +71,7 @@ export default function Projects({}: {  }) {
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const session = await getSession(context);
 
-    if (!session || !session.userId) {
-        context.res.setHeader("location", session ? "/auth/newaccount" : "/auth/signin");
-        context.res.statusCode = 302;
-        context.res.end();
-    }
+    if (!session || !session.userId) return {redirect: {permanent: false, destination: session ? "/auth/newaccount" : "/auth/signin"}};
 
     return {props: {}};
 };

--- a/pages/projects/[projectId].tsx
+++ b/pages/projects/[projectId].tsx
@@ -676,12 +676,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     // check auth
     const session = await getSession(context);
 
-    if (!session || !session.userId) {
-        context.res.setHeader("location", session ? "/auth/newaccount" : "/auth/signin");
-        context.res.statusCode = 302;
-        context.res.end();
-        return {props: {}};
-    }
+    if (!session || !session.userId) return {redirect: {permanent: false, destination: session ? "/auth/newaccount" : "/auth/signin"}};
 
     // fetch project info from MongoDB
     try {

--- a/pages/quick.tsx
+++ b/pages/quick.tsx
@@ -53,11 +53,7 @@ export default function QuickSnippetPage() {
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const session = await getSession(context);
 
-    if (!session || !session.userId) {
-        context.res.setHeader("location", session ? "/auth/newaccount" : "/auth/signin");
-        context.res.statusCode = 302;
-        context.res.end();
-    }
+    if (!session || !session.userId) return {redirect: {permanent: false, destination: session ? "/auth/newaccount" : "/auth/signin"}};
 
     return {props: {}};
 };

--- a/pages/r/[projectUrlName].tsx
+++ b/pages/r/[projectUrlName].tsx
@@ -1,0 +1,40 @@
+import {GetServerSideProps} from "next";
+import {getSession} from "next-auth/client";
+import dbConnect from "../../utils/dbConnect";
+import {ProjectModel} from "../../models/project";
+
+export default function ProjectRedirect() {
+    return <></>
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    // 404 if not correct url format
+    if (Array.isArray(context.params.projectUrlName)) return {notFound: true};
+
+    // check auth
+    const session = await getSession(context);
+
+    if (!session || !session.userId) return {
+        redirect: {
+            permanent: false,
+            destination: session ? "/auth/newaccount" : "/auth/signin"
+        }
+    };
+
+    // fetch project info from MongoDB
+    try {
+        await dbConnect();
+
+        const projectUrlName = context.params.projectUrlName;
+
+        const thisProject = await ProjectModel.findOne({urlName: projectUrlName});
+
+        if (!thisProject) return {notFound: true};
+
+        return {redirect: {permanent: false, destination: `/projects/${thisProject._id.toString()}`}};
+    } catch (e) {
+        console.log(e);
+
+        return {notFound: true};
+    }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+    scroll-behavior: smooth;
+}
+
 body, div.chart-container {
     font-family: "IBM Plex Sans", sans-serif;
     color: #3F3F46;

--- a/utils/copy.ts
+++ b/utils/copy.ts
@@ -1,0 +1,1 @@
+export const snippetsExplainer = "Snippets are source notes that eventually turn into posts.";

--- a/utils/htmlDecode.ts
+++ b/utils/htmlDecode.ts
@@ -1,0 +1,7 @@
+import jsdom from "jsdom";
+const { JSDOM } = jsdom;
+
+export default function htmlDecode(input: string): string {
+    const dom = new JSDOM(input);
+    return dom.window.document.body.textContent;
+}

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -107,6 +107,7 @@ export interface SnippetObj {
 }
 
 export interface SnippetObjGraph extends SnippetObj {
+    projectArr: DatedObj<ProjectObj>[];
     linkedPostsArr: ({authorArr: DatedObj<UserObj>[]} & DatedObj<PostObj>)[];
     authorArr: DatedObj<UserObj>[];
     linkArr: DatedObj<LinkObj>[];

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -53,6 +53,10 @@ export interface ProjectObjWithOwner extends ProjectObj {
     ownerArr: DatedObj<UserObj>[],
 }
 
+export interface ProjectObjWithOwnerWithProjects extends ProjectObj {
+    ownerArr: DatedObj<UserObjWithProjects>[],
+}
+
 export interface ProjectObjBasic {
     urlName: string,
     userId: string, // ID
@@ -107,7 +111,7 @@ export interface SnippetObj {
 }
 
 export interface SnippetObjGraph extends SnippetObj {
-    projectArr: DatedObj<ProjectObj>[];
+    projectArr: DatedObj<ProjectObjWithOwnerWithProjects>[];
     linkedPostsArr: ({authorArr: DatedObj<UserObj>[]} & DatedObj<PostObj>)[];
     authorArr: DatedObj<UserObj>[];
     linkArr: DatedObj<LinkObj>[];

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -135,8 +135,8 @@ export interface PostObjGraph extends PostObj {
     authorArr: IdObj<UserObjBasic>[],
 }
 
-export interface PostWithAuthor extends PostObj {
-    author: DatedObj<UserObj>[],
+export interface PostObjWithAuthor extends PostObj {
+    authorArr: DatedObj<UserObj>[],
 }
 
 export interface ImageObj {
@@ -180,8 +180,8 @@ export interface NotificationObj {
 }
 
 export interface NotificationWithAuthorAndTarget extends NotificationObj {
-    comment: (DatedObj<CommentObj> & {post: DatedObj<PostWithAuthor>[], author: DatedObj<UserObj>[]})[],
-    reaction: (DatedObj<ReactionObj> & {post: DatedObj<PostWithAuthor>[], author: DatedObj<UserObj>[]})[],
+    comment: (DatedObj<CommentObj> & {post: DatedObj<PostObjWithAuthor>[], authorArr: DatedObj<UserObj>[]})[],
+    reaction: (DatedObj<ReactionObj> & {post: DatedObj<PostObjWithAuthor>[], authorArr: DatedObj<UserObj>[]})[],
 }
 
 interface LinkObjBase {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -103,6 +103,7 @@ export interface SnippetObj {
     url: string,
     tags: string[],
     linkedPosts: string[], // array of IDs
+    privacy: "public" | "private",
 }
 
 export interface SnippetObjGraph extends SnippetObj {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -23,12 +23,6 @@ export interface UserObj {
     featuredPosts: string[], // array of IDs
 }
 
-export interface UserObjBasic {
-    name: string,
-    username: string,
-    image: string,
-}
-
 export interface ProjectObj {
     urlName: string,
     userId: string, // ID
@@ -65,7 +59,7 @@ export interface ProjectObjBasic {
 }
 
 export interface ProjectObjBasicWithOwner extends ProjectObjBasic {
-    ownerArr: IdObj<UserObjBasic>[],
+    ownerArr: DatedObj<UserObj>[],
 }
 
 export interface ProjectObjWithPageStats extends ProjectObj {
@@ -131,8 +125,8 @@ export interface PostObj {
 }
 
 export interface PostObjGraph extends PostObj {
-    projectArr: IdObj<ProjectObjBasicWithOwner>[],
-    authorArr: IdObj<UserObjBasic>[],
+    projectArr: DatedObj<ProjectObjBasicWithOwner>[],
+    authorArr: DatedObj<UserObj>[],
 }
 
 export interface PostObjWithAuthor extends PostObj {

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -257,7 +257,13 @@ export const snippetGraphStages = [
             foreignField: "nodeId",
             localField: "_id",
             as: "linkArr",
-        }}
+        }},
+    {$lookup: {
+        from: "projects",
+            foreignField: "_id",
+            localField: "projectId",
+            as: "projectArr",
+        }},
 ];
 
 const userPipeline = [

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -260,8 +260,28 @@ export const snippetGraphStages = [
         }},
     {$lookup: {
         from: "projects",
-            foreignField: "_id",
-            localField: "projectId",
+            let: {"projectId": "$projectId"},
+            pipeline: [
+                {$match: {$expr: {$eq: ["$_id", "$$projectId"]}}},
+                {
+                    $lookup: {
+                        from: "users",
+                        let: {"userId": "$userId"},
+                        pipeline: [
+                            {$match: {$expr: {$eq: ["$_id", "$$userId"]}}},
+                            {$lookup:
+                                    {
+                                        from: "projects",
+                                        foreignField: "userId",
+                                        localField: "_id",
+                                        as: "projectsArr",
+                                    }
+                            },
+                        ],
+                        as: "ownerArr",
+                    }
+                },
+            ],
             as: "projectArr",
         }},
 ];

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -1,7 +1,7 @@
 import {ToolbarDropdownIcon, ToolbarIcon} from "easymde";
 import {format, subDays} from "date-fns";
 import {Node} from "slate";
-import {DatedObj, ProjectObj} from "./types";
+import {ProjectObj} from "./types";
 
 export function cleanForJSON(input: any): any {
     return JSON.parse(JSON.stringify(input));
@@ -286,22 +286,16 @@ export const snippetGraphStages = [
         }},
 ];
 
-const userPipeline = [
-    {$match: {$expr: {$eq: ["$_id", "$$userId"]}}},
-    {$project: {username: 1, image: 1, name: 1}},
-];
-
 export const postGraphStages = [
     {$lookup: {
             from: "projects",
             let: {"projectId": "$projectId"},
             pipeline: [
                 {$match: {$expr: {$eq: ["$_id", "$$projectId"]}}},
-                {$project: {name: 1, urlName: 1, userId: 1, stars: 1,}},
                 {$lookup: {
                         from: "users",
-                        let: {"userId": "$userId"},
-                        pipeline: userPipeline,
+                        localField: "userId",
+                        foreignField: "_id",
                         as: "ownerArr",
                     }},
             ],
@@ -309,8 +303,8 @@ export const postGraphStages = [
         }},
     {$lookup: {
             from: "users",
-            let: {"userId": "$userId"},
-            pipeline: userPipeline,
+            localField: "userId",
+            foreignField: "_id",
             as: "authorArr",
         }},
 ];


### PR DESCRIPTION
PS-38	Public snippet setting
PS-205	Make linked snippets on post page card format // just redo the whole thing
PS-207	make private project pages easier to go to, i.e. /projects/scratch rather than /[id]
PS-208	Add back to private project button from public project
PS-212	Add explainer text for snippets under posts
PS-214 *	Public snippet page
PS-215 *	Show public snippets on project page
PS-217 *	Filter for public snippets in project snippet tab
PS-219 *	Show public snippets on profile page
PS-220 *	show project on snippet card on profile page
PS-221 *	Fix post preview uri encoding (bug)
PS-222 *	URL for snippet tab on project page
PS-223 *	Make all projects easier to get to
PS-224 *	Fix PostFeedItem error in project page